### PR TITLE
add statsd instrumentation to licence-finder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rails', '3.2.7'
 gem "mongoid", "~> 2.4"
 gem "bson_ext", "~> 1.5"
 gem "tire"
+gem "statsd-ruby"
 
 gem 'router-client', '~> 3.0.1', :require => 'router'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,7 @@ GEM
       hike (~> 1.2)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
+    statsd-ruby (1.0.0)
     therubyracer (0.10.1)
       libv8 (~> 3.3.10)
     thor (0.15.4)
@@ -221,6 +222,7 @@ DEPENDENCIES
   rspec-rails (~> 2.11.0)
   rummageable (~> 0.1.3)
   slimmer (~> 1.1.45)
+  statsd-ruby
   therubyracer
   tire
   uglifier (>= 1.0.3)

--- a/app/controllers/licence_finder_controller.rb
+++ b/app/controllers/licence_finder_controller.rb
@@ -1,4 +1,5 @@
 require "slimmer/headers"
+require 'statsd'
 
 class LicenceFinderController < ApplicationController
   include Slimmer::Headers
@@ -22,6 +23,7 @@ class LicenceFinderController < ApplicationController
   end
 
   def sectors
+    Statsd.new('localhost').increment('licence-finder.starts')
     @picked_sectors = Sector.find_by_public_ids(extract_ids(:sector)).ascending(:name).to_a
     if params[:q].present?
       @sectors = $search.search(params[:q])
@@ -55,6 +57,7 @@ class LicenceFinderController < ApplicationController
   end
 
   def licences
+    Statsd.new('localhost').increment('licence-finder.finishes')
     @sectors = Sector.find_by_public_ids(@sector_ids)
     @activities = Activity.find_by_public_ids(@activity_ids)
     @location = params[:location]


### PR DESCRIPTION
Talked this over briefly with Kush this afternoon.

Adding incredibly simple statsd instrumentation to licence-finder. Every time someone hits /sectors we record a start, and every time someone hits /licences we record a finish.

The metrics are then made available in the graphite dashboard -- go to eg http://monitoring.preview.alphagov.co.uk/dashboard and find the metric in the folders at the left-hand side of the screen. The metric won't exist until this pull request is merged and the app starts running the new code; the metric is automagically created when the first bits of data are sent.

There are obviously some issues with this particular example -- eg /sectors is likely to be cached at the CDN so we may well miss some starts. This is just intended to demonstrate how to add instrumentation to an app.
