### PR TITLE
Search results fix

### DIFF
--- a/app/assets/stylesheets/licence-finder.scss
+++ b/app/assets/stylesheets/licence-finder.scss
@@ -177,6 +177,10 @@ a.add {
     margin-top: 0;
   }
 
+  .inner {
+    padding: 0;
+  }
+
   h3 {
     @include core-19;
     margin-top: 0;


### PR DESCRIPTION
Search results section took up the whole page width. This brings it into line with the browse section.
