### PR TITLE
Apply ttl to api cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'router-client', '~> 3.0.1', :require => 'router'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '3.3.0'
+  gem 'gds-api-adapters', '3.4.1'
 end
 
 gem 'rummageable', '~> 0.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
     faye-websocket (0.4.6)
       eventmachine (>= 0.12.0)
     ffi (1.0.11)
-    gds-api-adapters (3.3.0)
+    gds-api-adapters (3.4.1)
       lrucache (~> 0.1.1)
       null_logger
       plek
@@ -221,7 +221,7 @@ DEPENDENCIES
   database_cleaner
   exception_notification
   factory_girl_rails (~> 3.2.0)
-  gds-api-adapters (= 3.3.0)
+  gds-api-adapters (= 3.4.1)
   govuk_frontend_toolkit (= 0.2.1)
   lograge
   mongoid (~> 2.4)


### PR DESCRIPTION
Presently, items are remaining in the cache for a large amount of time due to the small number of different API requests in this app.
