### PR TITLE
Disable XML and JSON parsers

### DIFF
--- a/config/initializers/param_parsers.rb
+++ b/config/initializers/param_parsers.rb
@@ -1,0 +1,4 @@
+# Turn off XML parsing:
+# https://groups.google.com/forum/#!topic/rubyonrails-security/61bkgvnSGTQ/discussion
+ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::XML)
+ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::JSON)


### PR DESCRIPTION
We don't appear to be using these so we should reduce the app's surface area by disabling them.
