### PR TITLE
Bump toolkit 3.32.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,4 +54,4 @@ group :development, :test do
   gem 'webmock', '~> 1.8.7', :require => false
 end
 
-gem 'govuk_frontend_toolkit', '0.2.1'
+gem 'govuk_frontend_toolkit', '0.32.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,8 +71,9 @@ GEM
       lrucache (~> 0.1.1)
       null_logger
       plek
-    govuk_frontend_toolkit (0.2.1)
+    govuk_frontend_toolkit (0.32.2)
       rails (>= 3.1.0)
+      sass (>= 3.2.0)
     hashr (0.0.21)
     hike (1.2.1)
     http_parser.rb (0.5.3)
@@ -228,7 +229,7 @@ DEPENDENCIES
   exception_notification
   factory_girl_rails (~> 3.2.0)
   gds-api-adapters (= 4.1.3)
-  govuk_frontend_toolkit (= 0.2.1)
+  govuk_frontend_toolkit (= 0.32.2)
   lograge (= 0.2.0)
   mongoid (= 2.4.9)
   mongoid_rails_migrations (= 1.0.1)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,9 +14,7 @@
           <hgroup>
             <h1><span>Quick answer</span> Licence finder</h1>
           </hgroup>
-          <nav class="skip-to-related">
-            <a href="#related">Not what you're looking for? ↓</a>
-          </nav>
+          <a class="skip-to-related" href="#related">Not what you're looking for? ↓</a>
         </header>
         <%= yield %>
       </section>


### PR DESCRIPTION
Includes an update to the skip-link missed from this set of pull requests: https://github.com/alphagov/static/pull/238

Continuation of this work: https://github.com/alphagov/static/pull/270

Associated with (though they don't need to be merged simultaneously):

https://github.com/alphagov/business-support-finder/pull/31
https://github.com/alphagov/calendars/pull/37
https://github.com/alphagov/design-principles/pull/47
https://github.com/alphagov/feedback/pull/53
https://github.com/alphagov/smart-answers/pull/466
https://github.com/alphagov/trade-tariff-frontend/pull/80
https://github.com/alphagov/transaction-wrappers/pull/28
