### PR TITLE
Remove the next-step button when business items are unselected

### DIFF
--- a/app/assets/javascripts/licence-finder.js
+++ b/app/assets/javascripts/licence-finder.js
@@ -191,8 +191,8 @@ $(function() {
             if ($("#next-step").length === 0) {
                 target.append('<div class="button-container"><a class="button medium" id="next-step">Next step</a></div>');
             }
-        } else if (source.find("li").length === 0) {
-            $(".hidden", source).removeClass("hidden").addClass("hint");
+        } else if (target.find("li").length === 0) {
+            $(".hidden", target).removeClass("hidden").addClass("hint");
             $("#next-step").remove();
         }
         $("#next-step").attr("href", createNextUrl());


### PR DESCRIPTION
Clicking the remove link on a selected business item, when it is the last one, does not currently remove the next-step button.

https://www.pivotaltracker.com/s/projects/537731/stories/55151484

Linked to https://github.com/alphagov/business-support-finder/pull/37
