### PR TITLE
Clean up gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "tire"
 
 gem 'mongoid_rails_migrations', '1.0.1'
 
-gem 'router-client', '~> 3.0.1', :require => 'router'
+gem 'router-client', '3.0.1', :require => 'router'
 
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
@@ -33,8 +33,8 @@ gem 'exception_notification'
 
 group :assets do
   gem 'sass', '3.2.0'
-  gem 'sass-rails', '~> 3.2.3'
-  gem 'uglifier', '>= 1.0.3'
+  gem 'sass-rails', '3.2.5'
+  gem 'uglifier', '1.2.4'
 end
 
 if ENV['RUBY_DEBUG']
@@ -42,12 +42,12 @@ if ENV['RUBY_DEBUG']
 end
 
 group :development, :test do
-  gem 'rspec-rails', '~> 2.11.0'
-  gem 'factory_girl_rails', '~> 3.2.0'
+  gem 'rspec-rails', '2.11.0'
+  gem 'factory_girl_rails', '3.2.0'
   gem 'database_cleaner'
-  gem 'capybara', '~> 1.1.2'
-  gem 'poltergeist', "~> 0.7.0"
-  gem 'webmock', '~> 1.8.7', :require => false
+  gem 'capybara', '1.1.2'
+  gem 'poltergeist', "0.7.0"
+  gem 'webmock', '1.8.7', :require => false
 end
 
 gem 'govuk_frontend_toolkit', '0.32.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,25 +221,25 @@ PLATFORMS
 DEPENDENCIES
   aws-ses
   bson_ext (= 1.6.2)
-  capybara (~> 1.1.2)
+  capybara (= 1.1.2)
   database_cleaner
   exception_notification
-  factory_girl_rails (~> 3.2.0)
+  factory_girl_rails (= 3.2.0)
   gds-api-adapters (= 4.1.3)
   govuk_frontend_toolkit (= 0.32.2)
   lograge (= 0.2.0)
   mongoid (= 2.4.9)
   mongoid_rails_migrations (= 1.0.1)
   plek (= 1.1.0)
-  poltergeist (~> 0.7.0)
+  poltergeist (= 0.7.0)
   rails (= 3.2.13)
-  router-client (~> 3.0.1)
-  rspec-rails (~> 2.11.0)
+  router-client (= 3.0.1)
+  rspec-rails (= 2.11.0)
   rummageable (~> 0.1.3)
   sass (= 3.2.0)
-  sass-rails (~> 3.2.3)
+  sass-rails (= 3.2.5)
   slimmer (= 3.17.0)
   tire
-  uglifier (>= 1.0.3)
+  uglifier (= 1.2.4)
   unicorn (= 4.3.1)
-  webmock (~> 1.8.7)
+  webmock (= 1.8.7)


### PR DESCRIPTION
- Remove `therubyracer` gem as we no longer need it and the current version doesn't build on Precise.
- Pin gem versions to reduce dependency lookup time
