### PR TITLE
Remove the router-client gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,6 @@ gem "tire"
 
 gem 'mongoid_rails_migrations', '1.0.1'
 
-gem 'router-client', '3.0.1', :require => 'router'
-
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,10 +143,6 @@ GEM
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    router-client (3.0.1)
-      activesupport
-      builder
-      null_logger
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
@@ -232,7 +228,6 @@ DEPENDENCIES
   plek (= 1.1.0)
   poltergeist (= 0.7.0)
   rails (= 3.2.16)
-  router-client (= 3.0.1)
   rspec-rails (= 2.11.0)
   rummageable (~> 0.1.3)
   sass (= 3.2.0)


### PR DESCRIPTION
This was only ever used for the old router, and is very deprecated.
