### PR TITLE
Removing 'not what you're looking for' link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,6 @@
           <div>
             <h1>Licence finder</h1>
           </div>
-          <a class="skip-to-related" href="#related">Not what you're looking for? ↓</a>
         </header>
         <%= yield %>
       </main>


### PR DESCRIPTION
Usage is negligible (0.352% of pageviews result in it being clicked) and it's a jarring experience

Related pull requests on other branches — 

alphagov/frontend/pull/512
alphagov/smart-answers/pull/700
alphagov/licence-finder/pull/51
alphagov/calendars/pull/57
alphagov/prototyping-v2/pull/1
alphagov/transaction-wrappers/pull/42
