### PR TITLE
Remove invalid need ID being sent to panopticon.

### DIFF
--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -13,7 +13,6 @@ namespace :panopticon do
         slug: APP_SLUG, 
         title: "Licence Finder", 
         description: "Find out which licences you might need for your activity or business.",
-        need_id: "B90", 
         section: "business",
         paths: [],
         prefixes: ["/#{APP_SLUG}"],


### PR DESCRIPTION
This is currently blocking deployment because panopticon rejects
non-maslow need IDs.  Fix this by removing it here.  The correct need ID
for this application can be added in the Panopticon UI.
