### PR TITLE
Update to work with slimmer wrapper layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
   </head>
   <body class="mainstream">
     <div id="wrapper" class="answer licence-finder <%= yield :page_class %>">
+      <% if content_for?(:after_content) %><div class="grid-row"><% end %>
       <main id="content" role="main">
         <header class="page-header group">
           <div>
@@ -18,6 +19,7 @@
         <%= yield %>
       </main>
       <%= yield :after_content %>
+      <% if content_for?(:after_content) %></div><% end %>
     </div>
   </body>
 </html>


### PR DESCRIPTION
By default the related links now float. This wraps the main and the
related in a grid row so that the elements float nicely together.
Otherwise the related links will float into the page footer.

This is the change needed to go with alphagov/static#530