### PR TITLE
Fix issue with phantom JS loading assets

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,3 +1,7 @@
 require "capybara/poltergeist"
 
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, { phantomjs_options: ['--ssl-protocol=TLSv1'] })
+end
+
 Capybara.javascript_driver = :poltergeist


### PR DESCRIPTION
phantomjs defaults to using SSLv3, which has now been disabled
everywhere. The protocol used can be changed with an option:

--ssl-protocol= Sets the SSL protocol
(supported protocols: 'SSLv3' (default), 'SSLv2', 'TLSv1', 'any')
This PR makes poltergeist set this option when invoking phantomjs.