### PR TITLE
Use new elasticsearch cluster in production.

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -9,7 +9,7 @@ test:
     type:  sector
 
 production:
-    url:   'http://support.cluster:9200'
+    url:   'http://localhost:9200'
     index: licence-finder
     type:  sector
 

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -8,11 +8,6 @@ class Search
     client_config = HashWithIndifferentAccess.new(YAML.load_file(config_path))
     client_config = client_config[environment].merge(client_config[:all_envs])
 
-    # FIXME: remove this override once migration is complete.
-    if ENV['OVERRIDE_ES_URL'].present?
-      client_config[:url] = ENV['OVERRIDE_ES_URL']
-    end
-
     Rails.logger.instance_eval do
       alias :write :info
     end


### PR DESCRIPTION
This is accessed via a local load-balancer, hence using localhost:9200.