### PR TITLE
Bump slimmer for rendering app meta tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'logstasher', '0.4.8'
 if ENV['SLIMMER_DEV']
   gem "slimmer", :path => '../slimmer'
 else
-  gem "slimmer", '8.1.0'
+  gem "slimmer", '8.2.1'
 end
 
 gem 'aws-ses', :require => 'aws/ses' # Needed by exception_notification

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    slimmer (8.1.0)
+    slimmer (8.2.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -220,7 +220,7 @@ DEPENDENCIES
   rummageable (~> 0.1.3)
   sass (= 3.2.0)
   sass-rails (= 3.2.5)
-  slimmer (= 8.1.0)
+  slimmer (= 8.2.1)
   tire
   uglifier (= 1.2.4)
   unicorn (= 4.3.1)


### PR DESCRIPTION
So we can track which application renders which page in analytics update
slimmer for a new version which outputs the rendering application.

This contains both https://github.com/alphagov/slimmer/pull/126 and https://github.com/alphagov/slimmer/pull/128
