### PR TITLE
Bump gds api adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'mongoid_rails_migrations', '1.0.1'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '8.2.1'
+  gem 'gds-api-adapters', '20.1.1'
 end
 
 gem 'rummageable', '~> 0.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
     crack (0.3.1)
     database_cleaner (0.7.2)
     diff-lcs (1.1.3)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     exception_notification (2.5.2)
       actionmailer (>= 3.0.4)
@@ -61,17 +63,20 @@ GEM
     factory_girl_rails (3.2.0)
       factory_girl (~> 3.2.0)
       railties (>= 3.0.0)
-    gds-api-adapters (8.2.1)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
-      rest-client (~> 1.6.3)
+      rack-cache
+      rest-client (~> 1.8.0)
     govuk_frontend_toolkit (0.32.2)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hashr (0.0.21)
     hike (1.2.3)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     journey (1.0.4)
     json (1.8.3)
@@ -98,6 +103,7 @@ GEM
       rails (>= 3.2.0)
       railties (>= 3.2.0)
     multi_json (1.11.1)
+    netrc (0.10.3)
     nokogiri (1.5.11)
     null_logger (0.0.1)
     plek (1.1.0)
@@ -134,8 +140,10 @@ GEM
     rake (10.4.2)
     rdoc (3.12.2)
       json (~> 1.4)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
@@ -186,6 +194,9 @@ GEM
     uglifier (1.2.4)
       execjs (>= 0.3.0)
       multi_json (>= 1.0.2)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.3.1)
       kgio (~> 2.6)
       rack
@@ -208,7 +219,7 @@ DEPENDENCIES
   database_cleaner
   exception_notification
   factory_girl_rails (= 3.2.0)
-  gds-api-adapters (= 8.2.1)
+  gds-api-adapters (= 20.1.1)
   govuk_frontend_toolkit (= 0.32.2)
   logstasher (= 0.4.8)
   mongoid (= 2.4.9)


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information