### PR TITLE
Bump gds-api-adapter version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'mongoid_rails_migrations', '1.0.1'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '20.1.1'
+  gem 'gds-api-adapters', '~> 24.4.0'
 end
 
 gem 'rummageable', '~> 0.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     factory_girl_rails (3.2.0)
       factory_girl (~> 3.2.0)
       railties (>= 3.0.0)
-    gds-api-adapters (20.1.1)
+    gds-api-adapters (24.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -224,7 +224,7 @@ DEPENDENCIES
   database_cleaner
   exception_notification
   factory_girl_rails (= 3.2.0)
-  gds-api-adapters (= 20.1.1)
+  gds-api-adapters (~> 24.4.0)
   govuk-content-schema-test-helpers
   govuk_frontend_toolkit (= 0.41.1)
   logstasher (= 0.4.8)


### PR DESCRIPTION
This is to ensure that content id is correctly sent to panopticon via the registerer.