### PR TITLE
Upgrade Slimmer, explicitly set 'wrapper' layout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'logstasher', '0.4.8'
 if ENV['SLIMMER_DEV']
   gem "slimmer", :path => '../slimmer'
 else
-  gem "slimmer", '8.2.1'
+  gem "slimmer", '9.0.0'
 end
 
 gem 'aws-ses', :require => 'aws/ses' # Needed by exception_notification

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
-    slimmer (8.2.1)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -237,7 +237,7 @@ DEPENDENCIES
   rummageable (~> 0.1.3)
   sass (= 3.2.0)
   sass-rails (= 3.2.5)
-  slimmer (= 8.2.1)
+  slimmer (= 9.0.0)
   tire
   uglifier (= 1.2.4)
   unicorn (= 4.3.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,9 @@
 require "slimmer/headers"
 require "gds_api/helpers"
 class ApplicationController < ActionController::Base
+  include Slimmer::Template
+  slimmer_template 'wrapper'
+
   protected
   rescue_from GdsApi::TimedOutException, :with => :error_503
 


### PR DESCRIPTION
This should be a no-op change to app behaviour. The Slimmer default was 'wrapper'
before the upgrade, and is not explicitly set.

Slimmer 9.0.0 switched to `core_layout` [1] as the default layout, which is the
modern/recommend layout. Apps not yet using `core_layout` should be explicitly
marked as such, so we can easily identify them as needing updating.

I had a quick look at what would be required to use a modern layout;

- `header_footer_only`:
 - Needs a `related` component
 - button styling
 - some formatting for "Popular licences" list
- `core_layout`:
 - the above, plus...
 - breadcrumbs
 - heading (and subheading) styling

[1] https://github.com/alphagov/slimmer/pull/136