### PR TITLE
Fix Errbit config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '3.2.22'
 gem 'unicorn', '4.3.1'
-gem 'plek', '1.1.0'
+gem 'plek', '1.11.0'
 
 gem "mongoid", "2.4.9"
 gem "bson_ext", "1.6.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,8 +106,7 @@ GEM
     netrc (0.10.3)
     nokogiri (1.5.11)
     null_logger (0.0.1)
-    plek (1.1.0)
-      builder
+    plek (1.11.0)
     poltergeist (1.5.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -224,7 +223,7 @@ DEPENDENCIES
   logstasher (= 0.4.8)
   mongoid (= 2.4.9)
   mongoid_rails_migrations (= 1.0.1)
-  plek (= 1.1.0)
+  plek (= 1.11.0)
   poltergeist (= 1.5.1)
   rails (= 3.2.22)
   rspec-rails (= 2.11.0)


### PR DESCRIPTION
The Errbit config was using a method added to a a later version of Plek than
licence-finder was using.

This meant that deployment failed.

/cc @elliotcm @dsingleton 