### PR TITLE
Use v2 of publishing-api to write app metadata to content store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "airbrake", "4.3.1"
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 24.4.0'
+  gem 'gds-api-adapters', '~> 25.1'
 end
 
 gem 'rummageable', '~> 0.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
-    gds-api-adapters (24.4.0)
+    gds-api-adapters (25.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -136,7 +136,7 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     rack (1.6.4)
-    rack-cache (1.5.0)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -252,7 +252,7 @@ DEPENDENCIES
   capybara (= 2.5.0)
   database_cleaner (~> 1.4.0)
   factory_girl_rails (~> 4.5.0)
-  gds-api-adapters (~> 24.4.0)
+  gds-api-adapters (~> 25.1)
   govuk-content-schema-test-helpers
   govuk_frontend_toolkit (= 0.41.1)
   logstasher (= 0.4.8)

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -6,6 +6,7 @@ class PublishingApiNotifier
   end
 
   def publish(presenter)
-    Services.publishing_api.put_content_item(presenter.base_path, presenter.payload)
+    Services.publishing_api.put_content(presenter.content_id, presenter.payload)
+    Services.publishing_api.publish(presenter.content_id, presenter.update_type)
   end
 end

--- a/app/presenters/licence_finder_content_item_presenter.rb
+++ b/app/presenters/licence_finder_content_item_presenter.rb
@@ -3,15 +3,24 @@ class LicenceFinderContentItemPresenter
     "/" + metadata[:slug]
   end
 
+  def content_id
+    metadata[:content_id]
+  end
+
+  def update_type
+    'minor'
+  end
+
   def payload
     {
+      base_path: base_path,
       title: metadata[:title],
       description: metadata[:description],
-      content_id: metadata[:content_id],
+      content_id: content_id,
       format: 'placeholder_licence_finder',
       publishing_app: 'licencefinder',
       rendering_app: 'licencefinder',
-      update_type: 'minor',
+      update_type: update_type,
       locale: 'en',
       public_updated_at: Time.now.iso8601,
       routes: [

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,7 +1,7 @@
-require 'gds_api/publishing_api'
+require 'gds_api/publishing_api_v2'
 
 module Services
   def self.publishing_api
-    @publishing_api ||= GdsApi::PublishingApi.new(Plek.new.find('publishing-api'))
+    @publishing_api ||= GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
   end
 end

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -2,10 +2,11 @@ require "services"
 
 RSpec.describe PublishingApiNotifier do
   describe "#publish" do
-    let(:presenter) { double("content_item_presenter", base_path: "/licence-finder", payload: {test: :payload}) }
+    let(:presenter) { double("content_item_presenter", content_id: '69af22e0-da49-4810-9ee4-22b4666ac627', update_type: 'minor', payload: {test: :payload}) }
 
     it "publishes the content item" do
-      expect(Services.publishing_api).to receive(:put_content_item).with("/licence-finder", {test: :payload})
+      expect(Services.publishing_api).to receive(:put_content).with('69af22e0-da49-4810-9ee4-22b4666ac627', {test: :payload})
+      expect(Services.publishing_api).to receive(:publish).with('69af22e0-da49-4810-9ee4-22b4666ac627', 'minor')
 
       PublishingApiNotifier.publish(presenter)
     end


### PR DESCRIPTION
All apps should now use v2 of the publishing api to write content to the content-store.  This change converts licence-finder to use v2 of the api.  The differences are:

- put content_item is replaced by two methods - put_content, and publish
- the content_id is used as the key, rather than the base path
- the base path is included in the payload