### PR TITLE
Test against v2 schemas

### DIFF
--- a/app/presenters/licence_finder_content_item_presenter.rb
+++ b/app/presenters/licence_finder_content_item_presenter.rb
@@ -16,11 +16,9 @@ class LicenceFinderContentItemPresenter
       base_path: base_path,
       title: metadata[:title],
       description: metadata[:description],
-      content_id: content_id,
       format: 'placeholder_licence_finder',
       publishing_app: 'licencefinder',
       rendering_app: 'licencefinder',
-      update_type: update_type,
       locale: 'en',
       public_updated_at: Time.now.iso8601,
       routes: [

--- a/spec/presenters/licence_finder_content_item_presenter_spec.rb
+++ b/spec/presenters/licence_finder_content_item_presenter_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe LicenceFinderContentItemPresenter do
 
     it "has the correct data" do
       expect(subject.payload[:title]).to eq "Licence Finder"
-      expect(subject.payload[:content_id]).to eq "69af22e0-da49-4810-9ee4-22b4666ac627"
     end
   end
 end

--- a/spec/support/schema_tests.rb
+++ b/spec/support/schema_tests.rb
@@ -1,7 +1,7 @@
 require 'govuk-content-schema-test-helpers/rspec_matchers'
 
 GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = 'publisher'
+  config.schema_type = 'publisher_v2'
   config.project_root = Rails.root
 end
 


### PR DESCRIPTION
This app was still sending old-style payload to the publishing-api.

https://trello.com/c/catWOsWC