### PR TITLE
Fix schema testing

### DIFF
--- a/app/presenters/licence_finder_content_item_presenter.rb
+++ b/app/presenters/licence_finder_content_item_presenter.rb
@@ -16,11 +16,13 @@ class LicenceFinderContentItemPresenter
       base_path: base_path,
       title: metadata[:title],
       description: metadata[:description],
-      format: 'placeholder_licence_finder',
+      document_type: 'placeholder_licence_finder',
+      schema_name: 'placeholder_licence_finder',
       publishing_app: 'licencefinder',
       rendering_app: 'licencefinder',
       locale: 'en',
       public_updated_at: Time.now.iso8601,
+      details: {},
       routes: [
         { type: 'exact', path: base_path }
       ]

--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export REPO_NAME="alphagov/govuk-content-schemas"
+export CONTEXT_MESSAGE="Verify licence-finder against content schemas"
+
+exec ./jenkins.sh


### PR DESCRIPTION
This fixes the payload sent to publishing-api and adds a script to be used to jenkins. This will fix this repo failing on master.

Corresponding jenkins job: https://ci.dev.publishing.service.gov.uk/job/govuk_licence_finder_schema_tests/