### PR TITLE
Rake task to add licence finder pages to the search index

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ bowl licencefinder
 ```
 
 If you are using the GDS development virtual machine then the application will be available on the host at http://licencefinder.dev.gov.uk/licence-finder
+
+### Publishing to GOV.UK
+
+- `bundle exec rake panopticon:register` will send the licence finder pages to panopticon. Panopticon will register the URL.
+
+### Search indexing
+
+- `bundle exec rake rummager:index_all` will send the data to Rummager for indexing in search.

--- a/app/notifiers/rummager_notifier.rb
+++ b/app/notifiers/rummager_notifier.rb
@@ -1,0 +1,24 @@
+require 'gds_api/rummager'
+require 'ostruct'
+
+class RummagerNotifier
+  def self.notify
+    new.notify
+  end
+
+  def notify
+    logger.info "Indexing '#{licence_finder_page.title}' in rummager..."
+
+    SearchIndexer.call(licence_finder_page)
+  end
+
+private
+
+  def licence_finder_page
+    @licence_finder_page ||= OpenStruct.new(APPLICATION_METADATA)
+  end
+
+  def logger
+    GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
+  end
+end

--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -1,0 +1,30 @@
+class SearchPayloadPresenter
+  attr_reader :licence_finder_page
+  delegate :slug,
+           :title,
+           :description,
+           :indexable_content,
+           :content_id,
+           to: :licence_finder_page
+
+  def initialize(licence_finder_page)
+    @licence_finder_page = licence_finder_page
+  end
+
+  def self.call(licence_finder_page)
+    new(licence_finder_page).call
+  end
+
+  def call
+    {
+      content_id: content_id,
+      rendering_app: 'licencefinder',
+      publishing_app: 'licencefinder',
+      format: 'custom-application',
+      title: title,
+      description: description,
+      indexable_content: indexable_content,
+      link: "/#{slug}"
+    }
+  end
+end

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -1,0 +1,32 @@
+require 'services'
+
+class SearchIndexer
+  attr_reader :licence_finder_page
+  delegate :slug, to: :licence_finder_page
+
+  def initialize(licence_finder_page)
+    @licence_finder_page = licence_finder_page
+  end
+
+  def self.call(licence_finder_page)
+    new(licence_finder_page).call
+  end
+
+  def call
+    Services.rummager.add_document(document_type, document_id, payload)
+  end
+
+private
+
+  def document_type
+    'edition'
+  end
+
+  def document_id
+    "/#{slug}"
+  end
+
+  def payload
+    SearchPayloadPresenter.call(licence_finder_page)
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,4 +1,5 @@
 require 'gds_api/publishing_api_v2'
+require 'gds_api/rummager'
 
 module Services
   def self.publishing_api
@@ -6,5 +7,9 @@ module Services
       Plek.new.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
     )
+  end
+
+  def self.rummager
+    @rummager ||= GdsApi::Rummager.new(Plek.find("search"))
   end
 end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,0 +1,6 @@
+namespace :rummager do
+  desc "Indexes the licence finder page in Rummager"
+  task index_all: :environment do
+    RummagerNotifier.notify
+  end
+end

--- a/spec/notifiers/rummager_notifier_spec.rb
+++ b/spec/notifiers/rummager_notifier_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe RummagerNotifier do
+  describe '#notify' do
+    it 'indexes the license finder page' do
+      expect(SearchIndexer).to receive(:call)
+
+      described_class.notify
+    end
+  end
+end

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/rummager'
+
+RSpec.describe SearchIndexer do
+  include GdsApi::TestHelpers::Rummager
+
+  before do
+    stub_any_rummager_post_with_queueing_enabled
+  end
+
+  it 'indexes the licence finder page in rummager' do
+    licence_finder_page = OpenStruct.new(APPLICATION_METADATA)
+    described_class.call(licence_finder_page)
+
+    assert_rummager_posted_item(
+      _type: 'edition',
+      _id: "/#{licence_finder_page.slug}",
+      rendering_app: "licencefinder",
+      publishing_app: "licencefinder",
+      format: "custom-application",
+      title: licence_finder_page.title,
+      description: licence_finder_page.description,
+      indexable_content: licence_finder_page.indexable_content,
+      link: "/#{licence_finder_page.slug}"
+    )
+  end
+end


### PR DESCRIPTION
Previously, panopticon would send artifacts to Rummager. That flow is now being
deprecated in favour of a simpler approach which is to send documents directly
to rummager.

This commit adds a class that allows us to add licence finder pages to the
search index directly. It also adds a rake task `rummager:index_all` whose job
is to index license finder pages in Rummager.

The payload now includes the following extra attributes:

- publishing_app
- rendering_app
- content_id

Before, the search results looked like this:

<img width="1175" alt="licence-finder-before" src="https://cloud.githubusercontent.com/assets/416701/18636427/ac1fbf42-7e80-11e6-9bbc-cd448446edc3.png">

it now looks like this:

<img width="1172" alt="licence-finder-after" src="https://cloud.githubusercontent.com/assets/416701/18636433/b275ffd2-7e80-11e6-90c1-aec32db9b72d.png">

Trello ticket: https://trello.com/c/gsHnT5WF/161-epic-send-things-to-rummager-directly-instead-of-via-panopticon