### PR TITLE
Correct rummager rake task name

### DIFF
--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,6 +1,6 @@
 namespace :rummager do
   desc "Indexes the licence finder page in Rummager"
-  task index_all: :environment do
+  task index: :environment do
     RummagerNotifier.notify
   end
 end


### PR DESCRIPTION
This ensures the default rummager:index task defined in govuk-app-deployment
can· correctly invoke this task.