### PR TITLE
Fetch metadata from content-store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,13 +24,14 @@ gem 'logstasher', '~> 0.6.0'
 if ENV['SLIMMER_DEV']
   gem "slimmer", :path => '../slimmer'
 else
-  gem "slimmer", '9.5.0'
+  gem "slimmer", '9.6.0'
 end
 
 gem 'sass-rails', '~> 5.0.4'
 gem 'uglifier', '~> 3.0.2'
 
 gem 'govuk_frontend_toolkit', '~> 4.18.0'
+gem 'govuk_navigation_helpers', '~> 2.0.0'
 
 gem 'govuk-lint'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     govuk_frontend_toolkit (4.18.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
+    govuk_navigation_helpers (2.0.0)
     hashdiff (0.3.0)
     hashr (0.0.22)
     http-cookie (1.0.2)
@@ -218,7 +219,7 @@ GEM
     scss_lint (0.40.1)
       rainbow (~> 2.0)
       sass (~> 3.4.1)
-    slimmer (9.5.0)
+    slimmer (9.6.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -278,6 +279,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_frontend_toolkit (~> 4.18.0)
+  govuk_navigation_helpers (~> 2.0.0)
   logstasher (~> 0.6.0)
   mongoid (~> 5.1.0)
   mongoid_rails_migrations (~> 1.1.0)
@@ -287,11 +289,11 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rspec-rails (~> 3.5.0)
   sass-rails (~> 5.0.4)
-  slimmer (= 9.5.0)
+  slimmer (= 9.6.0)
   tire
   uglifier (~> 3.0.2)
   unicorn (~> 5.1.0)
   webmock (~> 2.1.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
+++ b/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
@@ -1,0 +1,7 @@
+// GOV.UK components expect to live in a world with a global reset. This CSS
+// might be pushed up to static at some point.
+.govuk-breadcrumbs ol,
+.govuk-related-items ul {
+  padding: 0;
+  margin: 0;
+}

--- a/app/assets/stylesheets/licence-finder.scss
+++ b/app/assets/stylesheets/licence-finder.scss
@@ -1,6 +1,7 @@
 @import "_conditionals";
 @import "_typography";
 @import "_css3";
+@import "helpers/govuk-component-helpers";
 
 /* see multi-step.css.erb in the static repo for most of these styles */
 
@@ -107,8 +108,8 @@ a.add {
 
       &:nth-child(even) {
         background-color: #e8f0f0;
-      } 
-      
+      }
+
       a {
         float: right;
         padding-left: 0.25em;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
-require "slimmer/headers"
-
 class ApplicationController < ActionController::Base
   include Slimmer::Template
+  include Slimmer::SharedTemplates
+
   slimmer_template 'wrapper'
 
   # Prevent CSRF attacks by raising an exception.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,20 +6,32 @@
     <%= stylesheet_link_tag "licence-finder" %>
     <%= javascript_include_tag 'licence-finder', defer: true %>
     <%= yield :head %>
+    <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+    <% if @meta_section %>
+      <meta name="govuk:section" content="<%= @meta_section %>">
+    <% end %>
   </head>
   <body class="mainstream">
+    <div class="header-context"><!-- Deliberately empty. This will prevent Slimmer from adding the artefact-breadcrumb. --></div>
     <div id="wrapper" class="answer licence-finder <%= yield :page_class %>">
-      <% if content_for?(:after_content) %><div class="grid-row"><% end %>
-      <main id="content" role="main">
-        <header class="page-header group">
-          <div>
-            <h1>Licence finder</h1>
-          </div>
-        </header>
-        <%= yield %>
-      </main>
-      <%= yield :after_content %>
-      <% if content_for?(:after_content) %></div><% end %>
+    <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
+      <% unless @sectors %><div class="grid-row"><% end %>
+
+        <main id="content" role="main">
+          <header class="page-header group">
+            <div>
+              <h1>Licence finder</h1>
+            </div>
+          </header>
+          <%= yield %>
+        </main>
+
+      <% unless @sectors %>
+        <div class="related-container">
+          <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>
+        </div>
+      </div>
+      <% end %>
     </div>
   </body>
 </html>

--- a/app/views/licence_finder/start.html.erb
+++ b/app/views/licence_finder/start.html.erb
@@ -38,7 +38,3 @@
     </div>
   </article>
 </div>
-
-<% content_for :after_content do %>
-  <div id="related-items"></div>
-<% end %>

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,9 +1,24 @@
+require 'gds_api/content_api'
+require 'gds_api/content_store'
+require 'gds_api/panopticon'
 require 'gds_api/publishing_api_v2'
 require 'gds_api/rummager'
-require 'gds_api/content_api'
-require 'gds_api/panopticon'
 
 module Services
+  def self.content_api
+    @content_api ||= GdsApi::ContentApi.new(Plek.current.find("contentapi"))
+  end
+
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new(
+      Plek.new.find('content-store')
+    )
+  end
+
+  def self.panopticon_registerer
+    @panopticon_registerer ||= GdsApi::Panopticon::Registerer.new(owning_app: "licencefinder")
+  end
+
   def self.publishing_api
     @publishing_api ||= GdsApi::PublishingApiV2.new(
       Plek.new.find('publishing-api'),
@@ -13,13 +28,5 @@ module Services
 
   def self.rummager
     @rummager ||= GdsApi::Rummager.new(Plek.find("rummager"))
-  end
-
-  def self.content_api
-    @content_api ||= GdsApi::ContentApi.new(Plek.current.find("contentapi"))
-  end
-
-  def self.panopticon_registerer
-    @panopticon_registerer ||= GdsApi::Panopticon::Registerer.new(owning_app: "licencefinder")
   end
 end

--- a/spec/controllers/licence_finder_controller_spec.rb
+++ b/spec/controllers/licence_finder_controller_spec.rb
@@ -13,15 +13,6 @@ RSpec.describe LicenceFinderController, type: :controller do
       expect(response).to be_success
     end
 
-    it "fetches the artefact and pass it to slimmer" do
-      artefact_data = artefact_for_slug(APP_SLUG)
-      content_api_has_an_artefact(APP_SLUG, artefact_data)
-
-      get :start
-
-      expect(response.headers[Slimmer::Headers::ARTEFACT_HEADER]).to eq(artefact_data.to_json)
-    end
-
     it "returns 503 if the request times out" do
       stub_request(:get, %r{\A#{GdsApi::TestHelpers::ContentApi::CONTENT_API_ENDPOINT}}).to_timeout
       artefact_for_slug(APP_SLUG)
@@ -123,39 +114,6 @@ RSpec.describe LicenceFinderController, type: :controller do
       expect(response).to be_success
       expect(assigns[:picked_sectors]).to eq([@s3, @s2])
     end
-
-    it "returns slimmer headers" do
-      expect($search).to receive(:search).with("test query").and_return([])
-      get :sectors, q: "test query"
-      expect(response.headers["X-Slimmer-Format"]).to eq("finder")
-      expect(response.headers["X-Slimmer-Result-Count"]).to eq("0")
-    end
-
-    it "fetches the artefact and pass it to slimmer" do
-      artefact_data = artefact_for_slug(APP_SLUG)
-      content_api_has_an_artefact(APP_SLUG, artefact_data)
-
-      get :sectors
-
-      expect(response.headers[Slimmer::Headers::ARTEFACT_HEADER]).to eq(artefact_data.to_json)
-    end
-
-    it "does not return result count if no query was provided" do
-      get :sectors
-      expect(response.headers["X-Slimmer-Result-Count"]).to be_nil
-    end
-
-    it "returns slimmer result count when available" do
-      @s1 = FactoryGirl.create(:sector, name: "Alpha")
-      @s2 = FactoryGirl.create(:sector, name: "Charlie")
-      @s3 = FactoryGirl.create(:sector, name: "Bravo")
-
-      expect($search).to receive(:search).with("test query").and_return([@s1, @s2, @s3])
-
-      get :sectors, q: "test query"
-      expect(response).to be_success
-      expect(response.headers["X-Slimmer-Result-Count"]).to eq("3")
-    end
   end
 
   describe "GET 'activities'" do
@@ -208,20 +166,6 @@ RSpec.describe LicenceFinderController, type: :controller do
 
         expect(assigns[:picked_activities]).to eq([a1, a3, a2])
       end
-
-      it "does not return result count slimmer header" do
-        do_get
-        expect(response.headers).not_to have_key("X-Slimmer-Result-Count")
-      end
-
-      it "fetches the artefact and pass it to slimmer" do
-        artefact_data = artefact_for_slug(APP_SLUG)
-        content_api_has_an_artefact(APP_SLUG, artefact_data)
-
-        do_get
-
-        expect(response.headers[Slimmer::Headers::ARTEFACT_HEADER]).to eq(artefact_data.to_json)
-      end
     end
 
     context "with no valid sectors selected" do
@@ -269,15 +213,6 @@ RSpec.describe LicenceFinderController, type: :controller do
         ])
         expect(assigns[:current_question]).to eq(@question3)
         expect(assigns[:upcoming_questions]).to eq([])
-      end
-
-      it "fetches the artefact and pass it to slimmer" do
-        artefact_data = artefact_for_slug(APP_SLUG)
-        content_api_has_an_artefact(APP_SLUG, artefact_data)
-
-        do_get
-
-        expect(response.headers[Slimmer::Headers::ARTEFACT_HEADER]).to eq(artefact_data.to_json)
       end
     end
 
@@ -357,15 +292,6 @@ RSpec.describe LicenceFinderController, type: :controller do
             [@question2, :some_activities, 'activities'],
             [@question3, ['Northern Ireland'], 'business_location']
         ])
-      end
-
-      it "fetches the artefact and pass it to slimmer" do
-        artefact_data = artefact_for_slug(APP_SLUG)
-        content_api_has_an_artefact(APP_SLUG, artefact_data)
-
-        do_get
-
-        expect(response.headers[Slimmer::Headers::ARTEFACT_HEADER]).to eq(artefact_data.to_json)
       end
     end
 

--- a/spec/integration/browse_sectors_homepage_spec.rb
+++ b/spec/integration/browse_sectors_homepage_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe "Browse sectors via licence finder homepage", type: :request do
 
     expect(page).to have_content @s1.name
     expect(page).to have_css 'ul#sector-navigation'
+
+    expect(page).to have_css(shared_component_selector('breadcrumbs'))
+    expect(page).not_to have_css(shared_component_selector('related_items'))
   end
 
   specify "3rd level sectors should be able to be added to the sidebar", js: true do

--- a/spec/integration/browse_sectors_page_spec.rb
+++ b/spec/integration/browse_sectors_page_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe "Sector browse page", type: :request do
       expect(page).to have_content @s6.name
       expect(page).not_to have_content @s3.name
     end
+
+    expect(page).to have_css(shared_component_selector('breadcrumbs'))
+    expect(page).not_to have_css(shared_component_selector('related_items'))
   end
 
   specify "clicking through drills down the tree" do

--- a/spec/integration/licences_page_spec.rb
+++ b/spec/integration/licences_page_spec.rb
@@ -57,6 +57,9 @@ RSpec.describe "Licences page", type: :request do
     expect(page).not_to have_selector(*selector_of_section('upcoming questions'))
 
     expect(page).not_to have_content("No licences")
+
+    expect(page).to have_css(shared_component_selector('breadcrumbs'))
+    expect(page).not_to have_css(shared_component_selector('related_items'))
   end
 
   describe "getting licence details from content API" do

--- a/spec/integration/sectors_page_spec.rb
+++ b/spec/integration/sectors_page_spec.rb
@@ -40,6 +40,9 @@ RSpec.describe "Sector selection page", type: :request do
         'Where will you be located?'
       ])
     end
+
+    expect(page).to have_css(shared_component_selector('breadcrumbs'))
+    expect(page).not_to have_css(shared_component_selector('related_items'))
   end
 
   specify "with sectors selected" do

--- a/spec/integration/start_page_spec.rb
+++ b/spec/integration/start_page_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe "Start page", type: :request do
     end
 
     expect(page).to have_selector("#test-report_a_problem")
+    expect(page).to have_css(shared_component_selector('breadcrumbs'))
+    expect(page).to have_css(shared_component_selector('related_items'))
   end
 
   context "Seeing popular licences on the start page" do

--- a/spec/support/slimmer.rb
+++ b/spec/support/slimmer.rb
@@ -1,1 +1,1 @@
-require 'slimmer/test'
+require 'slimmer/rspec'

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -3,5 +3,8 @@ require 'webmock/rspec'
 RSpec.configure do |config|
   config.before(:each) do
     WebMock.disable_net_connect!(allow_localhost: true)
+
+    stub_request(:get, Plek.new.find("content-store") + "/content/licence-finder").to_return(body: {}.to_json)
+    stub_request(:get, %r{#{Plek.new.find("static")}/templates/locales(.*)}).to_return(body: {}.to_json)
   end
 end


### PR DESCRIPTION
Replace Content API with Content Store

Trello: https://trello.com/c/kDPWjD5T/175-render-breadcrumb-sidebar-meta-tags-from-content-store-in-license-finder