### PR TITLE
Use better document type

### DIFF
--- a/app/presenters/licence_finder_content_item_presenter.rb
+++ b/app/presenters/licence_finder_content_item_presenter.rb
@@ -16,7 +16,7 @@ class LicenceFinderContentItemPresenter
       base_path: base_path,
       title: metadata[:title],
       description: metadata[:description],
-      document_type: 'placeholder_licence_finder',
+      document_type: 'license_finder',
       schema_name: 'placeholder_licence_finder',
       publishing_app: 'licencefinder',
       rendering_app: 'licencefinder',


### PR DESCRIPTION
By using `license_finder` as the document type we'll be able to segment this page better in Analytics via `govuk:format`.

Before https://github.com/alphagov/licence-finder/pull/86 `govuk:format` used to be `finder`.

cc @rubenarakelyan 