### PR TITLE
Add result count header for search results

### DIFF
--- a/app/controllers/licence_finder_controller.rb
+++ b/app/controllers/licence_finder_controller.rb
@@ -1,6 +1,8 @@
 require 'services'
 
 class LicenceFinderController < ApplicationController
+  include Slimmer::Headers
+
   SEPARATOR = '_'.freeze
   QUESTIONS = [
     'What is your activity or business?',
@@ -21,6 +23,7 @@ class LicenceFinderController < ApplicationController
   before_filter :extract_and_validate_activity_ids, except: [:start, :sectors, :sectors_submit, :activities, :browse_sector_index, :browse_sector, :browse_sector_child, :browse_sector_grandchild]
   before_filter :set_expiry
   before_filter :setup_navigation_helpers
+  after_action :add_analytics_headers
 
   def start
     setup_popular_licences
@@ -164,5 +167,11 @@ protected
   def setup_popular_licences
     licences = POPULAR_LICENCE_IDS.map { |id| Licence.find_by_gds_id(id) }.compact
     @popular_licences = LicenceFacade.create_for_licences(licences).select(&:published?).first(3)
+  end
+
+  def add_analytics_headers
+    if @sectors && params[:q].present?
+      set_slimmer_headers(result_count: @sectors.length)
+    end
   end
 end

--- a/spec/controllers/licence_finder_controller_spec.rb
+++ b/spec/controllers/licence_finder_controller_spec.rb
@@ -114,6 +114,31 @@ RSpec.describe LicenceFinderController, type: :controller do
       expect(response).to be_success
       expect(assigns[:picked_sectors]).to eq([@s3, @s2])
     end
+
+    it "returns slimmer headers" do
+      expect($search).to receive(:search).with("test query").and_return([])
+
+      get :sectors, q: "test query"
+
+      expect(response.headers["X-Slimmer-Result-Count"]).to eq("0")
+    end
+
+    it "does not return result count if no query was provided" do
+      get :sectors
+
+      expect(response.headers["X-Slimmer-Result-Count"]).to be_nil
+    end
+
+    it "returns slimmer result count when available" do
+      @s1 = FactoryGirl.create(:sector, name: "Alpha")
+      @s2 = FactoryGirl.create(:sector, name: "Charlie")
+      @s3 = FactoryGirl.create(:sector, name: "Bravo")
+
+      expect($search).to receive(:search).with("test query").and_return([@s1, @s2, @s3])
+
+      get :sectors, q: "test query"
+      expect(response.headers["X-Slimmer-Result-Count"]).to eq("3")
+    end
   end
 
   describe "GET 'activities'" do


### PR DESCRIPTION
This was inadvertently removed in https://github.com/alphagov/licence-finder/pull/86.

https://trello.com/c/kDPWjD5T