### PR TITLE
Bump Slimmer and update code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'logstasher', '~> 0.6.0'
 if ENV['SLIMMER_DEV']
   gem "slimmer", :path => '../slimmer'
 else
-  gem "slimmer", '9.6.0'
+  gem "slimmer", '10.0.0'
 end
 
 gem 'sass-rails', '~> 5.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     scss_lint (0.40.1)
       rainbow (~> 2.0)
       sass (~> 3.4.1)
-    slimmer (9.6.0)
+    slimmer (10.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -289,7 +289,7 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rspec-rails (~> 3.5.0)
   sass-rails (~> 5.0.4)
-  slimmer (= 9.6.0)
+  slimmer (= 10.0.0)
   tire
   uglifier (~> 3.0.2)
   unicorn (~> 5.1.0)

--- a/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
+++ b/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
@@ -1,7 +1,0 @@
-// GOV.UK components expect to live in a world with a global reset. This CSS
-// might be pushed up to static at some point.
-.govuk-breadcrumbs ol,
-.govuk-related-items ul {
-  padding: 0;
-  margin: 0;
-}

--- a/app/assets/stylesheets/licence-finder.scss
+++ b/app/assets/stylesheets/licence-finder.scss
@@ -1,7 +1,6 @@
 @import "_conditionals";
 @import "_typography";
 @import "_css3";
-@import "helpers/govuk-component-helpers";
 
 /* see multi-step.css.erb in the static repo for most of these styles */
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Template
-  include Slimmer::SharedTemplates
+  include Slimmer::GovukComponents
 
   slimmer_template 'wrapper'
 


### PR DESCRIPTION
Finding Things has been working on migrating related links, part of that
work was to replace the breadcrumbs on a number of different frontend
applications like:

- calendars
- calculators
- business-support-finder
- frontend
- licence-finder
- smart-answers

That work has already been done, this commit aims to clean up things we
have missed during the migration.

This includes

- upgrading Slimmer to 10.0.0
- deletion of govuk-component-helpers.scss
- rename [Slimmer::SharedTemplates to Slimmer::GovukComponents](https://github.com/alphagov/slimmer/pull/173)

Trello: https://trello.com/c/5Utjs9qw/300-related-links-cleanup