### PR TITLE
Register routes via publishing-api instead of panopticon

### DIFF
--- a/app/presenters/licence_finder_content_item_presenter.rb
+++ b/app/presenters/licence_finder_content_item_presenter.rb
@@ -17,14 +17,14 @@ class LicenceFinderContentItemPresenter
       title: metadata[:title],
       description: metadata[:description],
       document_type: 'license_finder',
-      schema_name: 'placeholder_licence_finder',
+      schema_name: 'generic',
       publishing_app: 'licencefinder',
       rendering_app: 'licencefinder',
       locale: 'en',
       public_updated_at: Time.now.iso8601,
       details: {},
       routes: [
-        { type: 'exact', path: base_path }
+        { type: 'prefix', path: base_path }
       ]
     }
   end

--- a/config/initializers/application_metadata.rb
+++ b/config/initializers/application_metadata.rb
@@ -4,8 +4,12 @@ APPLICATION_METADATA = {
   title: "Licence Finder",
   description: "Find out which licences you might need for your activity or business.",
   section: "business",
+
+  # Sending an empty array for `paths` and `prefixes` will make sure we don't
+  # register routes in Panopticon.
   paths: [],
-  prefixes: ["/#{APP_SLUG}"],
+  prefixes: [],
+
   indexable_content: <<-HEREDOC.gsub(/\s+/, " ").strip,
     Find out which licences you might need for your
     activity or business, including temporary events notice, occasional licence,

--- a/spec/presenters/licence_finder_content_item_presenter_spec.rb
+++ b/spec/presenters/licence_finder_content_item_presenter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe LicenceFinderContentItemPresenter do
 
   describe "#payload" do
     it "is valid against the schema" do
-      expect(subject.payload).to be_valid_against_schema("placeholder")
+      expect(subject.payload).to be_valid_against_schema("generic")
     end
 
     it "has the correct data" do


### PR DESCRIPTION
This PR makes this application register its routes via the publishing-api instead of content-store.

It's part of the mainstream preparatory work to remove routing from panopticon.

https://trello.com/c/6eOYmUnL/1-register-routes-via-the-publishing-api-for-publisher-formats