### PR TITLE
Bump slimmer to use Rails' cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'logstasher', '~> 0.6.0'
 if ENV['SLIMMER_DEV']
   gem "slimmer", :path => '../slimmer'
 else
-  gem "slimmer", '10.0.0'
+  gem "slimmer", "~> 10.1.1"
 end
 
 gem 'sass-rails', '~> 5.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     scss_lint (0.40.1)
       rainbow (~> 2.0)
       sass (~> 3.4.1)
-    slimmer (10.0.0)
+    slimmer (10.1.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -289,7 +289,7 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rspec-rails (~> 3.5.0)
   sass-rails (~> 5.0.4)
-  slimmer (= 10.0.0)
+  slimmer (~> 10.1.1)
   tire
   uglifier (~> 3.0.2)
   unicorn (~> 5.1.0)

--- a/config/initializers/slimmer.rb
+++ b/config/initializers/slimmer.rb
@@ -1,10 +1,6 @@
 Rails.application.configure do
   config.slimmer.logger = Rails.logger
 
-  if Rails.env.production?
-    config.slimmer.use_cache = true
-  end
-
   if Rails.env.development?
     config.slimmer.asset_host = ENV["STATIC_DEV"] || "http://static.dev.gov.uk"
   end


### PR DESCRIPTION
This bumps slimmer to make it use the rails cache and send a user agent:

- https://github.com/alphagov/slimmer/pull/184
- https://github.com/alphagov/slimmer/pull/183

It will prevent this app from making many needless requests to `static`.

https://trello.com/c/D9HmkJwI