### PR TITLE
Revert "Bump slimmer to use Rails' cache"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'logstasher', '~> 0.6.0'
 if ENV['SLIMMER_DEV']
   gem "slimmer", :path => '../slimmer'
 else
-  gem "slimmer", "~> 10.1.1"
+  gem "slimmer", '10.0.0'
 end
 
 gem 'sass-rails', '~> 5.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     scss_lint (0.40.1)
       rainbow (~> 2.0)
       sass (~> 3.4.1)
-    slimmer (10.1.1)
+    slimmer (10.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -289,7 +289,7 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rspec-rails (~> 3.5.0)
   sass-rails (~> 5.0.4)
-  slimmer (~> 10.1.1)
+  slimmer (= 10.0.0)
   tire
   uglifier (~> 3.0.2)
   unicorn (~> 5.1.0)

--- a/config/initializers/slimmer.rb
+++ b/config/initializers/slimmer.rb
@@ -1,6 +1,10 @@
 Rails.application.configure do
   config.slimmer.logger = Rails.logger
 
+  if Rails.env.production?
+    config.slimmer.use_cache = true
+  end
+
   if Rails.env.development?
     config.slimmer.asset_host = ENV["STATIC_DEV"] || "http://static.dev.gov.uk"
   end


### PR DESCRIPTION
Reverts alphagov/licence-finder#99.

We're getting `TypeError: no _dump_data is defined for class OpenSSL::X509::Store` errors on staging when running this branch.

It looks like something in this app is causing the caching to crash. I suspect it's the old `RestClient` in this application.

https://errbit.staging.publishing.service.gov.uk/apps/560eb07d65786340ab340200/problems/58aec8b665786357eece0200