### PR TITLE
Replace tire with elasticsearch-ruby

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'unicorn', '~> 5.1.0'
 gem 'plek', '1.12.0'
 
 gem "mongoid", '~> 5.1.0'
-gem "tire"
+gem 'elasticsearch'
 
 gem 'mongoid_rails_migrations', '~> 1.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,6 @@ GEM
     airbrake (4.3.8)
       builder
       multi_json
-    ansi (1.5.0)
     arel (6.0.3)
     ast (2.3.0)
     bson (4.1.1)
@@ -62,6 +61,14 @@ GEM
     diff-lcs (1.2.5)
     domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
+    elasticsearch (5.0.4)
+      elasticsearch-api (= 5.0.4)
+      elasticsearch-transport (= 5.0.4)
+    elasticsearch-api (5.0.4)
+      multi_json
+    elasticsearch-transport (5.0.4)
+      faraday
+      multi_json
     erubis (2.7.0)
     execjs (2.7.0)
     factory_girl (4.7.0)
@@ -69,6 +76,8 @@ GEM
     factory_girl_rails (4.7.0)
       factory_girl (~> 4.7.0)
       railties (>= 3.0.0)
+    faraday (0.12.1)
+      multipart-post (>= 1.2, < 3)
     gds-api-adapters (33.1.0)
       link_header
       lrucache (~> 0.1.1)
@@ -88,7 +97,6 @@ GEM
       sass (>= 3.2.0)
     govuk_navigation_helpers (2.0.0)
     hashdiff (0.3.0)
-    hashr (0.0.22)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -125,6 +133,7 @@ GEM
       rails (>= 4.2.0)
       railties (>= 4.2.0)
     multi_json (1.12.1)
+    multipart-post (2.0.0)
     netrc (0.11.0)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -238,14 +247,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
-    tire (0.6.2)
-      activemodel (>= 3.0)
-      activesupport
-      ansi
-      hashr (~> 0.0.19)
-      multi_json (~> 1.3)
-      rake
-      rest-client (~> 1.6)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.2)
@@ -274,6 +275,7 @@ DEPENDENCIES
   airbrake (~> 4.3.1)
   capybara (~> 2.8.0)
   database_cleaner (~> 1.5.1)
+  elasticsearch
   factory_girl_rails (~> 4.7.0)
   gds-api-adapters (= 33.1.0)
   govuk-content-schema-test-helpers
@@ -290,10 +292,9 @@ DEPENDENCIES
   rspec-rails (~> 3.5.0)
   sass-rails (~> 5.0.4)
   slimmer (= 10.0.0)
-  tire
   uglifier (~> 3.0.2)
   unicorn (~> 5.1.0)
   webmock (~> 2.1.0)
 
 BUNDLED WITH
-   1.12.5
+   1.14.6

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -7,11 +7,23 @@ class Search
     config_path = Rails.root + 'config' + "elasticsearch.yml"
     client_config = HashWithIndifferentAccess.new(YAML.load_file(config_path))
     client_config = client_config[environment].merge(client_config[:all_envs])
+    index_name = client_config.delete(:index)
+    settings = client_config.delete(:create)
+    type = client_config.delete(:type)
 
     Rails.logger.instance_eval do
       alias :write :info
     end
-    client = Search::Client::Elasticsearch.new(client_config.merge(logger: Rails.logger))
+
+    client = Search::Client::Elasticsearch.new(
+      index_name: index_name,
+      settings: settings,
+      type: type,
+      config: client_config.merge(
+        logger: Rails.logger,
+        log: true
+      )
+    )
 
     Search.new(client)
   end

--- a/lib/search/client/elasticsearch.rb
+++ b/lib/search/client/elasticsearch.rb
@@ -68,9 +68,14 @@ class Search
 
         raw_search_results = client.search(
           index: index_name,
-          q: query,
-          fields: %w(public_id title extra_terms activities),
-          sort: '_score:desc',
+          body: {
+            query: {
+              query_string: {
+                fields: %w(title extra_terms activities),
+                query: query
+              }
+            }
+          }
         )
 
         raw_search_results['hits']['hits'].map do |result|

--- a/lib/search/client/search_result.rb
+++ b/lib/search/client/search_result.rb
@@ -1,0 +1,17 @@
+class Search
+  class Client
+    class SearchResult
+      attr_reader :raw_result
+
+      def initialize(raw_result)
+        @raw_result = raw_result
+      end
+
+      def public_id
+        public_id_result = raw_result.dig('fields', 'public_id') || []
+
+        public_id_result.first
+      end
+    end
+  end
+end

--- a/lib/search/client/search_result.rb
+++ b/lib/search/client/search_result.rb
@@ -8,9 +8,7 @@ class Search
       end
 
       def public_id
-        public_id_result = raw_result.dig('fields', 'public_id') || []
-
-        public_id_result.first
+        raw_result.dig('_source', 'public_id')
       end
     end
   end

--- a/spec/lib/search/client/elasticsearch_spec.rb
+++ b/spec/lib/search/client/elasticsearch_spec.rb
@@ -3,59 +3,116 @@ require "search/client/elasticsearch"
 
 RSpec.describe Search::Client::Elasticsearch do
   before(:each) do
+    @index_name = 'test-index'
     @es_config = {
         url:    'localhost',
-        index:  'test-index',
-        type:   'test-type',
-        create: 'test-create'
     }
-    @es_indexer = double
-    @client = Search::Client::Elasticsearch.new(@es_config)
-    allow(@client).to receive(:indexer).and_return(@es_indexer)
+    @client = Search::Client::Elasticsearch.new(
+      index_name: @index_name,
+      settings: 'test-create',
+      type: 'test-type',
+      config: @es_config
+    )
   end
 
   describe "indexing" do
     it "deletes and creates index with mapping before re-indexing" do
-      expect(@es_indexer).to receive(:delete)
-      expect(@es_indexer).to receive(:create).with("test-create").and_return(true)
+      allow_any_instance_of(
+        Elasticsearch::API::Indices::IndicesClient
+      ).to receive(:delete).with(index: @index_name, ignore: [404])
+
+      allow_any_instance_of(
+        Elasticsearch::API::Indices::IndicesClient
+      ).to receive(:create).with(index: @index_name, body: /.*/).and_return(true)
+
       @client.pre_index
     end
 
     it "indexes provided sectors" do
       s1 = FactoryGirl.create(:sector, public_id: 1, name: "Sector One")
-      s2 = FactoryGirl.create(:sector, public_id: 2, name: "Sector Two")
-      s3 = FactoryGirl.create(:sector, public_id: 3, name: "Sector Three")
-      # indexing = sequence("indexing")
-      expect(@client).to receive(:to_document).with(s1).and_return(:doc1)
-      expect(@es_indexer).to receive(:store).with(:doc1)
-      expect(@client).to receive(:to_document).with(s2).and_return(:doc2)
-      expect(@es_indexer).to receive(:store).with(:doc2)
-      expect(@client).to receive(:to_document).with(s3).and_return(:doc3)
-      expect(@es_indexer).to receive(:store).with(:doc3)
+      allow_any_instance_of(
+        Elasticsearch::Transport::Client
+      ).to receive(:create).with(
+        hash_including(@client.to_document(s1))
+      ).and_return(true)
 
-      @client.index [s1, s2, s3]
+      s2 = FactoryGirl.create(:sector, public_id: 2, name: "Sector Two")
+      allow_any_instance_of(
+        Elasticsearch::Transport::Client
+      ).to receive(:create).with(
+        hash_including(@client.to_document(s2))
+      ).and_return(true)
+
+      s3 = FactoryGirl.create(:sector, public_id: 3, name: "Sector Three")
+      allow_any_instance_of(
+        Elasticsearch::Transport::Client
+      ).to receive(:create).with(
+        hash_including(@client.to_document(s3))
+      ).and_return(true)
+
+      @client.index([s1, s2, s3])
     end
 
     it "converts a sector to a hash with the correct fields set" do
-      document = @client.to_document(FactoryGirl.build(:sector, public_id: 123, name: "Test Sector"))
-      expect(document).to eq(_id: 123, type: "test-type", public_id: 123, title: "Test Sector", extra_terms: [], activities: [])
+      document = @client.to_document(
+        FactoryGirl.build(
+          :sector,
+          public_id: 123,
+          name: "Test Sector"
+        )
+      )
+
+      expect(document).to eq(
+        id: 123,
+        type: "test-type",
+        body: {
+          public_id: 123,
+          title: "Test Sector",
+          extra_terms: [],
+          activities: []
+        }
+      )
     end
 
     it "adds extra_terms to document when available" do
-      allow(@client).to receive(:extra_terms).and_return(123 => %w(foo bar monkey))
-      document = @client.to_document(FactoryGirl.build(:sector, public_id: 321, correlation_id: 123, name: "Test Sector"))
-      expect(document).to eq(_id: 321, type: "test-type", public_id: 321, title: "Test Sector", extra_terms: %w(foo bar monkey), activities: [])
+      allow(@client).to receive(:extra_terms).and_return(
+        123 => %w(foo bar monkey)
+      )
+      document = @client.to_document(
+        FactoryGirl.build(
+          :sector,
+          public_id: 321,
+          correlation_id: 123,
+          name: "Test Sector"
+        )
+      )
+
+      expect(document).to eq(
+        id: 321,
+        type: "test-type",
+        body: {
+          public_id: 321,
+          title: "Test Sector",
+          extra_terms: %w(foo bar monkey),
+          activities: []
+        }
+      )
     end
 
     it "commits after re-indexing" do
-      expect(@es_indexer).to receive(:refresh)
+      allow_any_instance_of(
+        Elasticsearch::API::Indices::IndicesClient
+      ).to receive(:refresh).with(index: @index_name)
+
       @client.post_index
     end
   end
 
   describe "deleting" do
     it "deletes the index" do
-      expect(@es_indexer).to receive(:delete)
+      allow_any_instance_of(
+        Elasticsearch::API::Indices::IndicesClient
+      ).to receive(:delete).with(index: @index_name, ignore: [404])
 
       @client.delete_index
     end
@@ -63,19 +120,22 @@ RSpec.describe Search::Client::Elasticsearch do
 
   describe "searching" do
     it "searches the title with a text query and just returns ids" do
-      d1 = double
-      expect(d1).to receive(:public_id).and_return(123)
-      d2 = double
-      expect(d2).to receive(:public_id).and_return(234)
-      response = double
-      expect(response).to receive(:results).and_return([d1, d2])
+      es_response = {
+        'hits' => {
+          'hits' => [
+            { 'fields' => { 'public_id' => [123] } },
+            { 'fields' => { 'public_id' => [234] } },
+          ]
+        }
+      }
 
-      expect(Tire).to receive(:search).with(@es_config[:index], query: {
-              query_string: {
-                  fields: %w(title extra_terms activities),
-                  query: "query"
-              }
-          }).and_return(response)
+      allow_any_instance_of(Elasticsearch::Transport::Client).to receive(:search).with(
+        index: @index_name,
+        q: 'query',
+        fields: %w(public_id title extra_terms activities),
+        sort: '_score:desc',
+      ).and_return(es_response)
+
       expect(@client.search("query")).to eq([123, 234])
     end
   end

--- a/spec/lib/search/client/elasticsearch_spec.rb
+++ b/spec/lib/search/client/elasticsearch_spec.rb
@@ -123,17 +123,22 @@ RSpec.describe Search::Client::Elasticsearch do
       es_response = {
         'hits' => {
           'hits' => [
-            { 'fields' => { 'public_id' => [123] } },
-            { 'fields' => { 'public_id' => [234] } },
+            { '_source' => { 'public_id' => 123 } },
+            { '_source' => { 'public_id' => 234 } },
           ]
         }
       }
 
       allow_any_instance_of(Elasticsearch::Transport::Client).to receive(:search).with(
         index: @index_name,
-        q: 'query',
-        fields: %w(public_id title extra_terms activities),
-        sort: '_score:desc',
+        body: {
+          query: {
+            query_string: {
+              fields: %w(title extra_terms activities),
+              query: 'query'
+            }
+          }
+        }
       ).and_return(es_response)
 
       expect(@client.search("query")).to eq([123, 234])


### PR DESCRIPTION
### Background

We are in the process of removing all calls to the Content API, because we want to deprecate it in favour of the Content Store (and/or the Search API). In this case, we need to use the Search API to get licence information, which we will be migrating to soon. However, in the current version of `gds-api-adapters` (v33) the search endpoint is not yet available. Furthermore, we can't upgrade `gds-api-adapters` because of version issues imposed by `tire`. The rational here is to:

- move to a more modern Elasticsearch client library and use libraries that are supported;
- remove the dependency issues so that we can upgrade gds-api-adapters.

This commit replaces the retired `tire` gem, which is an ElasticSearch
client. That gem is old, unsupported and is preventing us from upgrading
the `gds-api-adapters` gem.

The interface changes slightly. Here are some of the differences:
- we now pass a `log: true` flag to tell the library to log;
- the structure of the data being indexed changed to include a `body`
  key/value which includes the details of the document.

I've tested:
- adding new documents to the index, which I can verify have the same
  structure as the old documents;
- delete and re-create the index, which also works as expected.

There are details below on what the documents/indexes look like.

Trello: https://trello.com/c/vlqSHmTZ/76-make-licence-finder-use-something-else-to-fetch-licenses

### More details

<details>
  <summary>The index definition (before)</summary>

```json
{
  "licence-finder-development": {
    "aliases": {

    },
    "mappings": {
      "sector": {
        "_all": {
          "auto_boost": true
        },
        "properties": {
          "activities": {
            "type": "string",
            "boost": 0.7,
            "store": true,
            "analyzer": "my_snowball"
          },
          "extra_terms": {
            "type": "string",
            "store": true,
            "analyzer": "my_snowball"
          },
          "public_id": {
            "type": "string",
            "index": "not_analyzed",
            "store": true
          },
          "title": {
            "type": "string",
            "store": true,
            "analyzer": "my_snowball",
            "fields": {
              "autocomplete": {
                "type": "string",
                "analyzer": "my_snowball"
              },
              "sortable": {
                "type": "string",
                "analyzer": "my_snowball"
              }
            }
          },
          "type": {
            "type": "string"
          }
        }
      }
    },
    "settings": {
      "index": {
        "creation_date": "1494504703752",
        "uuid": "QEjslFGrQ36YHvcX06ezKA",
        "analysis": {
          "analyzer": {
            "my_start": {
              "filter": [
                "asciifolding",
                "lowercase",
                "my_edge"
              ],
              "tokenizer": "whitespace"
            },
            "my_sort": {
              "filter": [
                "asciifolding",
                "lowercase"
              ],
              "tokenizer": "keyword"
            },
            "my_snowball": {
              "filter": [
                "standard",
                "lowercase",
                "stop",
                "my_synonym",
                "my_snowball"
              ],
              "tokenizer": "standard"
            }
          },
          "filter": {
            "my_synonym": {
              "type": "synonym",
              "synonyms": [
                "cafe, restaurant",
                "photography, photographic",
                "cleaner, clean"
              ]
            },
            "my_edge": {
              "max_gram": "10",
              "type": "edgeNGram",
              "min_gram": "1",
              "side": "front"
            },
            "my_snowball": {
              "type": "snowball",
              "language": "English"
            }
          }
        },
        "number_of_replicas": "0",
        "number_of_shards": "1",
        "version": {
          "created": "1070599"
        }
      }
    },
    "warmers": {

    }
  }
}
```
</details>

-------

<details>
  <summary>The index definition (after)</summary>

```json
{
  "licence-finder-development": {
    "aliases": {

    },
    "mappings": {
      "sector": {
        "_all": {
          "auto_boost": true
        },
        "properties": {
          "activities": {
            "type": "string",
            "boost": 0.7,
            "store": true,
            "analyzer": "my_snowball"
          },
          "extra_terms": {
            "type": "string",
            "store": true,
            "analyzer": "my_snowball"
          },
          "public_id": {
            "type": "string",
            "index": "not_analyzed",
            "store": true
          },
          "title": {
            "type": "string",
            "store": true,
            "analyzer": "my_snowball",
            "fields": {
              "autocomplete": {
                "type": "string",
                "analyzer": "my_snowball"
              },
              "sortable": {
                "type": "string",
                "analyzer": "my_snowball"
              }
            }
          },
          "type": {
            "type": "string"
          }
        }
      }
    },
    "settings": {
      "index": {
        "creation_date": "1494857555825",
        "uuid": "HyHvahLiR3S5AbzGFUfjiQ",
        "analysis": {
          "analyzer": {
            "my_start": {
              "filter": [
                "asciifolding",
                "lowercase",
                "my_edge"
              ],
              "tokenizer": "whitespace"
            },
            "my_sort": {
              "filter": [
                "asciifolding",
                "lowercase"
              ],
              "tokenizer": "keyword"
            },
            "my_snowball": {
              "filter": [
                "standard",
                "lowercase",
                "stop",
                "my_synonym",
                "my_snowball"
              ],
              "tokenizer": "standard"
            }
          },
          "filter": {
            "my_synonym": {
              "type": "synonym",
              "synonyms": [
                "cafe, restaurant",
                "photography, photographic",
                "cleaner, clean"
              ]
            },
            "my_edge": {
              "max_gram": "10",
              "type": "edgeNGram",
              "min_gram": "1",
              "side": "front"
            },
            "my_snowball": {
              "type": "snowball",
              "language": "English"
            }
          }
        },
        "number_of_replicas": "0",
        "number_of_shards": "1",
        "version": {
          "created": "1070599"
        }
      }
    },
    "warmers": {

    }
  }
}
```
</details>

-------

<details>
  <summary>An example document (before)</summary>

```json
{
  "_index": "licence-finder-development",
  "_type": "sector",
  "_id": "203",
  "_version": 1,
  "found": true,
  "_source": {
    "_id": 203,
    "type": "sector",
    "public_id": 203,
    "title": "Computer and computer peripherals manufacturing",
    "extra_terms": [

    ],
    "activities": [
      "Use CCTV systems",
      "Discharge rain water, cooling water or treated liquid effluent directly to controlled waters",
      "Carry out processes causing emissions to air",
      "Operate a goods vehicle",
      "Process, store or dispose of dangerous or harmful substances",
      "Posess or use equipment which may contain Polychlorinated Biphenyls (PCBs)",
      "Operate a large industrial site",
      "Produce, store or dispose of ozone-depleting substances",
      "Discharge trade effluent",
      "Undertake activities that cause solvent emissions - eg using paint, thinners, cleaning fluids etc",
      "Monitor, assess or report on energy consumption or levels of emissions and pollution",
      "Manufacture or supply electrical equipment"
    ]
  }
}
```
</details>

-------

<details>
  <summary>An example document (after)</summary>

```json
{
  "_index": "licence-finder-development",
  "_type": "sector",
  "_id": "203",
  "_version": 1,
  "found": true,
  "_source": {
    "_id": 203,
    "type": "sector",
    "public_id": 203,
    "title": "Computer and computer peripherals manufacturing",
    "extra_terms": [

    ],
    "activities": [
      "Use CCTV systems",
      "Discharge rain water, cooling water or treated liquid effluent directly to controlled waters",
      "Carry out processes causing emissions to air",
      "Operate a goods vehicle",
      "Process, store or dispose of dangerous or harmful substances",
      "Posess or use equipment which may contain Polychlorinated Biphenyls (PCBs)",
      "Operate a large industrial site",
      "Produce, store or dispose of ozone-depleting substances",
      "Discharge trade effluent",
      "Undertake activities that cause solvent emissions - eg using paint, thinners, cleaning fluids etc",
      "Monitor, assess or report on energy consumption or levels of emissions and pollution",
      "Manufacture or supply electrical equipment"
    ]
  }
}
```
</details>

### Links

- https://github.com/karmi/retire
- https://github.com/elastic/elasticsearch-ruby