### PR TITLE
Use Plek's website root as a prefix for links

### DIFF
--- a/app/models/licence_facade.rb
+++ b/app/models/licence_facade.rb
@@ -55,6 +55,6 @@ class LicenceFacade
 private
 
   def web_url
-    Plek.find('www') + @search_result['link']
+    Plek.current.website_root + @search_result['link']
   end
 end

--- a/spec/models/licence_facade_spec.rb
+++ b/spec/models/licence_facade_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe LicenceFacade, type: :model do
       end
 
       it "should return the frontend url" do
-        expect(@lf.url).to eq(Plek.find('www') + @pub_data['link'])
+        expect(@lf.url).to eq(Plek.current.website_root + @pub_data['link'])
       end
 
       it "should return the API short description" do


### PR DESCRIPTION
`Plek.find('www')` does not produce the expected URLs for integration and
staging. This change fixes this issue.

Trello: https://trello.com/c/vlqSHmTZ/76-make-licence-finder-use-something-else-to-fetch-licenses