### PR TITLE
Use separate content items for licence-finders

### DIFF
--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -1,8 +1,19 @@
 require 'services'
 
 class PublishingApiNotifier
-  def self.publish(presenter = LicenceFinderContentItemPresenter.new)
-    new.publish(presenter)
+  LICENCE_FINDER_FORM_DETAILS = {
+    "/licence-finder/sectors" => "4ade13fa-7e79-4bee-b809-61dbe5c3aa22",
+    "/licence-finder/activities" => "82162026-c815-4cc5-93ef-514fe467409a",
+    "/licence-finder/location" => "45cb0572-d71a-4c22-a84f-fdc53c2e7bc4",
+    "/licence-finder/licences" => "e1dc997a-3afe-4180-8c8d-880e7c1ca5a1",
+    "/licence-finder/browse-sectors" => "2cae8a3f-1231-4379-bdca-1de9b4668508"
+  }.freeze
+
+  def self.publish
+    LICENCE_FINDER_FORM_DETAILS.each do |base_path, content_id|
+      new.publish(LicenceFinderFormContentItemPresenter.new(base_path, content_id))
+    end
+    new.publish(LicenceFinderContentItemPresenter.new)
   end
 
   def publish(presenter)

--- a/app/presenters/licence_finder_content_item_presenter.rb
+++ b/app/presenters/licence_finder_content_item_presenter.rb
@@ -11,6 +11,10 @@ class LicenceFinderContentItemPresenter
     'minor'
   end
 
+  def route_type
+    'exact'
+  end
+
   def payload
     {
       base_path: base_path,
@@ -24,7 +28,7 @@ class LicenceFinderContentItemPresenter
       public_updated_at: Time.now.iso8601,
       details: {},
       routes: [
-        { type: 'prefix', path: base_path }
+        { type: route_type, path: base_path }
       ]
     }
   end

--- a/app/presenters/licence_finder_content_item_presenter.rb
+++ b/app/presenters/licence_finder_content_item_presenter.rb
@@ -25,7 +25,6 @@ class LicenceFinderContentItemPresenter
       publishing_app: 'licencefinder',
       rendering_app: 'licencefinder',
       locale: 'en',
-      public_updated_at: Time.now.iso8601,
       details: {},
       routes: [
         { type: route_type, path: base_path }

--- a/app/presenters/licence_finder_form_content_item_presenter.rb
+++ b/app/presenters/licence_finder_form_content_item_presenter.rb
@@ -1,0 +1,12 @@
+class LicenceFinderFormContentItemPresenter < LicenceFinderContentItemPresenter
+  attr_reader :base_path, :content_id
+
+  def initialize(base_path, content_id)
+    @base_path = base_path
+    @content_id = content_id
+  end
+
+  def route_type
+    'prefix'
+  end
+end

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -3,13 +3,20 @@ require "services"
 
 RSpec.describe PublishingApiNotifier do
   describe "#publish" do
-    let(:presenter) { double("content_item_presenter", content_id: '69af22e0-da49-4810-9ee4-22b4666ac627', update_type: 'minor', payload: { test: :payload }) }
+    it "publishes all content items" do
+      [
+        '69af22e0-da49-4810-9ee4-22b4666ac627',
+        "4ade13fa-7e79-4bee-b809-61dbe5c3aa22",
+        "82162026-c815-4cc5-93ef-514fe467409a",
+        "45cb0572-d71a-4c22-a84f-fdc53c2e7bc4",
+        "e1dc997a-3afe-4180-8c8d-880e7c1ca5a1",
+        "2cae8a3f-1231-4379-bdca-1de9b4668508",
+      ].each do |content_id|
+        expect(Services.publishing_api).to receive(:put_content).with(content_id, be_valid_against_schema('generic'))
+        expect(Services.publishing_api).to receive(:publish).with(content_id, 'minor')
+      end
 
-    it "publishes the content item" do
-      expect(Services.publishing_api).to receive(:put_content).with('69af22e0-da49-4810-9ee4-22b4666ac627', test: :payload)
-      expect(Services.publishing_api).to receive(:publish).with('69af22e0-da49-4810-9ee4-22b4666ac627', 'minor')
-
-      PublishingApiNotifier.publish(presenter)
+      PublishingApiNotifier.publish
     end
   end
 end

--- a/spec/presenters/licence_finder_form_content_item_presenter_spec.rb
+++ b/spec/presenters/licence_finder_form_content_item_presenter_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-RSpec.describe LicenceFinderContentItemPresenter do
-  let(:subject) { LicenceFinderContentItemPresenter.new }
+RSpec.describe LicenceFinderFormContentItemPresenter do
+  let(:subject) { LicenceFinderFormContentItemPresenter.new("/licence-finder/sectors", "4ade13fa-7e79-4bee-b809-61dbe5c3aa22") }
 
   describe "#base_path" do
     it "has the correct base path" do
-      expect(subject.base_path).to eq "/licence-finder"
+      expect(subject.base_path).to eq "/licence-finder/sectors"
     end
   end
 
@@ -18,14 +18,14 @@ RSpec.describe LicenceFinderContentItemPresenter do
       expect(subject.payload[:title]).to eq "Licence Finder"
     end
 
-    it 'uses an exact route' do
-      expect(subject.payload[:routes].first[:type]).to eql('exact')
+    it 'uses a prefix route' do
+      expect(subject.payload[:routes].first[:type]).to eql('prefix')
     end
   end
 
   describe '#content_id' do
     it 'has the expected content_id' do
-      expect(subject.content_id).to eql("69af22e0-da49-4810-9ee4-22b4666ac627")
+      expect(subject.content_id).to eql("4ade13fa-7e79-4bee-b809-61dbe5c3aa22")
     end
   end
 end


### PR DESCRIPTION
This publishes the start_page ("/licence-finder") to the Publishing API with an
exact route, to prepare for it to be published as a transaction by Publisher in
the future. The remaining licence-finder pages are published to the Publishing
API as content items with prefix routes.

After deploying this branch on integration, "/licence-finder/blah" returns a 404, confirming it is an exact route, and the content-id for "/licence-finder/sectors" is different from the "/licence-finder" content-id, confirming they are published as separate pieces of content.

**[DO NOT MERGE] for now as we're waiting to test this on integration tomorrow once it has fresh data.**

[Trello](https://trello.com/c/zboJadd9/409-3-republish-licence-finder-start-page-as-a-transaction-page-and-remove-hardcoded-version)