### PR TITLE
Move browse sectors index JSON into child route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,8 @@ Rails.application.routes.draw do
   get "#{APP_SLUG}/location" => "licence_finder#business_location", :as => :business_location
   post "#{APP_SLUG}/location" => "licence_finder#business_location_submit", :as => :business_location_submit
   get "#{APP_SLUG}/licences" => "licence_finder#licences", :as => :licences
-  get "#{APP_SLUG}/browse-sectors" => "licence_finder#browse_sector_index", :as => :browse_sector_index
+  get "#{APP_SLUG}/browse-sectors" => "licence_finder#browse_sector_index"
+  get "#{APP_SLUG}/browse-sectors/index" => "licence_finder#browse_sector_index", :as => :browse_sector_index
   get "#{APP_SLUG}/browse-sectors/:sector" => "licence_finder#browse_sector", :as => :browse_sector
   get "#{APP_SLUG}/browse-sectors/:sector_parent/:sector" => "licence_finder#browse_sector_child", :as => :browse_sector_child
 


### PR DESCRIPTION
Following on from #104 and in favour of #105

`/licence-finder/browse_sectors.json` is a route that doesn't make it to the licence finder application as `/licence-finder` is now an exact route (and will soon be served by another app) yet it also doesn't match the `/browse-sectors` prefix.

Switch to: `/licence-finder/browse_sectors/index.json`

https://trello.com/c/zboJadd9/409-3-republish-licence-finder-start-page-as-a-transaction-page-and-remove-hardcoded-version

@binaryberry 