### PR TITLE
Stop publishing the start page

### DIFF
--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -13,7 +13,6 @@ class PublishingApiNotifier
     LICENCE_FINDER_FORM_DETAILS.each do |base_path, content_id|
       new.publish(LicenceFinderFormContentItemPresenter.new(base_path, content_id))
     end
-    new.publish(LicenceFinderContentItemPresenter.new)
   end
 
   def publish(presenter)

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe PublishingApiNotifier do
   describe "#publish" do
     it "publishes all content items" do
       [
-        '69af22e0-da49-4810-9ee4-22b4666ac627',
         "4ade13fa-7e79-4bee-b809-61dbe5c3aa22",
         "82162026-c815-4cc5-93ef-514fe467409a",
         "45cb0572-d71a-4c22-a84f-fdc53c2e7bc4",
@@ -15,6 +14,13 @@ RSpec.describe PublishingApiNotifier do
         expect(Services.publishing_api).to receive(:put_content).with(content_id, be_valid_against_schema('generic'))
         expect(Services.publishing_api).to receive(:publish).with(content_id, 'minor')
       end
+
+      PublishingApiNotifier.publish
+    end
+
+    it "does not publish the start page" do
+      expect(Services.publishing_api).not_to receive(:put_content).with("69af22e0-da49-4810-9ee4-22b4666ac627", be_valid_against_schema('generic'))
+      expect(Services.publishing_api).not_to receive(:publish).with("69af22e0-da49-4810-9ee4-22b4666ac627", 'minor')
 
       PublishingApiNotifier.publish
     end


### PR DESCRIPTION
Depends on:
* [x] #104 and #106 deployed
* [ ] Publisher rake tasks in https://github.com/alphagov/publisher/pull/630 run
* [ ] New start page in Publisher is published

The start page is now published by Publisher and rendered by Frontend. This app doesn’t have permission to publish to it any more.

This will allow licence-finder to be deployable after the move of the start page.

https://trello.com/c/zboJadd9/409-3-republish-licence-finder-start-page-as-a-transaction-page-and-remove-hardcoded-version