### PR TITLE
Send update type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "airbrake", "~> 4.3.1"
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '45.0.0'
+  gem 'gds-api-adapters', '~> 47.2'
 end
 
 gem 'logstasher', '~> 0.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (45.0.0)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -279,7 +279,7 @@ DEPENDENCIES
   database_cleaner (~> 1.5.1)
   elasticsearch
   factory_girl_rails (~> 4.7.0)
-  gds-api-adapters (= 45.0.0)
+  gds-api-adapters (~> 47.2)
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_frontend_toolkit (~> 4.18.0)

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -17,6 +17,6 @@ class PublishingApiNotifier
 
   def publish(presenter)
     Services.publishing_api.put_content(presenter.content_id, presenter.payload)
-    Services.publishing_api.publish(presenter.content_id, presenter.update_type)
+    Services.publishing_api.publish(presenter.content_id)
   end
 end

--- a/app/presenters/licence_finder_content_item_presenter.rb
+++ b/app/presenters/licence_finder_content_item_presenter.rb
@@ -6,10 +6,6 @@ class LicenceFinderContentItemPresenter
     @content_id = content_id
   end
 
-  def update_type
-    'minor'
-  end
-
   def payload
     {
       base_path: base_path,
@@ -23,7 +19,8 @@ class LicenceFinderContentItemPresenter
       details: {},
       routes: [
         { type: 'prefix', path: base_path }
-      ]
+      ],
+      update_type: 'minor',
     }
   end
 

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PublishingApiNotifier do
         "2cae8a3f-1231-4379-bdca-1de9b4668508",
       ].each do |content_id|
         expect(Services.publishing_api).to receive(:put_content).with(content_id, be_valid_against_schema('generic'))
-        expect(Services.publishing_api).to receive(:publish).with(content_id, 'minor')
+        expect(Services.publishing_api).to receive(:publish).with(content_id)
       end
 
       PublishingApiNotifier.publish


### PR DESCRIPTION
Sending it on publish has been deprecated in favour of including it when sending a put content.

[Trello Card](https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)