### PR TITLE
Use multi_match when querying Elasticsearch

### DIFF
--- a/lib/search/client/elasticsearch.rb
+++ b/lib/search/client/elasticsearch.rb
@@ -70,7 +70,7 @@ class Search
           index: index_name,
           body: {
             query: {
-              query_string: {
+              multi_match: {
                 fields: %w(title extra_terms activities),
                 query: query
               }

--- a/lib/search/client/elasticsearch.rb
+++ b/lib/search/client/elasticsearch.rb
@@ -6,11 +6,6 @@ class Search
   class Client
     class Elasticsearch < Search::Client
       attr_accessor :client, :index_name, :settings, :type
-      ESCAPE_LUCENE_CHARS = /
-        ( [-+!\(\)\{\}\[\]^"~*?:\\] # A special character
-          | &&                        # Boolean &&
-          | \|\|                      # Boolean ||
-        )/x
 
       def initialize(index_name:, settings:, type:, config:)
         super(config)
@@ -62,10 +57,6 @@ class Search
       end
 
       def search(query)
-        return [] if query.match(ESCAPE_LUCENE_CHARS) && query.length <= 2
-
-        query = escape_lucene_chars(query)
-
         raw_search_results = client.search(
           index: index_name,
           body: {
@@ -81,17 +72,6 @@ class Search
         raw_search_results['hits']['hits'].map do |result|
           SearchResult.new(result).public_id
         end
-      end
-
-      # The Lucene documentation declares special characters to be:
-      #   + - && || ! ( ) { } [ ] ^ " ~ * ? : \
-      def escape_lucene_chars(s)
-        s.gsub(ESCAPE_LUCENE_CHARS) { |char| "\\#{char}" }
-      end
-
-      def downcase_ending_keywords(s)
-        escape_keywords_regex = /(AND$ | OR$ | NOT$)/x
-        s.gsub(escape_keywords_regex, &:downcase)
       end
     end
   end

--- a/spec/lib/search/client/elasticsearch_spec.rb
+++ b/spec/lib/search/client/elasticsearch_spec.rb
@@ -144,24 +144,4 @@ RSpec.describe Search::Client::Elasticsearch do
       expect(@client.search("query")).to eq([123, 234])
     end
   end
-
-  describe "Lucene search escaping characters" do
-    it "returns valid strings back" do
-      expect(@client.escape_lucene_chars("blargh")).to eq("blargh")
-      expect(@client.escape_lucene_chars("Testing")).to eq("Testing")
-    end
-
-    it "removes expected special chars" do
-      %w(+ - && || ! ( ) { } [ ] ^ " ~ * ? \ :).each { |char|
-        char.strip!
-        expect(@client.escape_lucene_chars("#{char}blargh")).to eq("\\#{char}blargh")
-      }
-    end
-
-    it "downcases search keywords" do
-      expect(@client.downcase_ending_keywords("bleh AND")).to eq("bleh and")
-      expect(@client.downcase_ending_keywords("bleh OR")).to eq("bleh or")
-      expect(@client.downcase_ending_keywords("bleh NOT")).to eq("bleh not")
-    end
-  end
 end

--- a/spec/lib/search/client/elasticsearch_spec.rb
+++ b/spec/lib/search/client/elasticsearch_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Search::Client::Elasticsearch do
         index: @index_name,
         body: {
           query: {
-            query_string: {
+            multi_match: {
               fields: %w(title extra_terms activities),
               query: 'query'
             }


### PR DESCRIPTION
Users are currently unable to search for activity or business types using terms that contain slashes, as this results in a server error.

![screen shot 2017-09-01 at 12 14 48](https://user-images.githubusercontent.com/121939/29967580-3647e056-8f0f-11e7-8da4-b769f8dd4804.png)

This is because we are using the [query string query type][1] to perform the search. This allows the user to use the full Lucene syntax to perform complex queries by combining terms and operators. However, it means that if the user wants to use an operator as part of a term they need to escape it. Elasticsearch is currently trying to interpret the slash as an operator and is not able to do so in a legal way, so returns an error.

![screen shot 2017-09-01 at 12 14 18](https://user-images.githubusercontent.com/121939/29967587-4445a922-8f0f-11e7-8480-80181c05446d.png)

By switching to use the [multi_match query type][2], Elasticsearch will treat the query as a simple term match against the specified fields. This means that the user will no longer be able to use Lucene query syntax, and that they will no longer need to escape slashes to get a valid response.

![screen shot 2017-09-01 at 12 13 29](https://user-images.githubusercontent.com/121939/29967602-4f4d6800-8f0f-11e7-9277-5272515b6ba3.png)

As the search field in the licence finder is only expected to be used for simple keyword matching, I believe this is a valid trade off to make.

[1]: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
[2]: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html