### PR TITLE
Use the ES 2.4 local proxy port

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -9,7 +9,7 @@ test:
     type:  sector
 
 production:
-    url:   <%= ENV['ELASTICSEARCH_URI'] || 'http://localhost:9200' %>
+    url:   <%= ENV['ELASTICSEARCH_URI'] || 'http://localhost:19200' %>
     index: licence-finder
     type:  sector
 


### PR DESCRIPTION
This is the first step to migrating to ES 2.4 and means we switch to using localhost:19200 to connect.

This PR is dependant on https://github.com/alphagov/govuk-puppet/pull/6465 being merged

https://trello.com/c/iDliRu73/315-licence-finder-on-es-24