### PR TITLE
Revert to default localproxy

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -9,7 +9,7 @@ test:
     type:  sector
 
 production:
-    url:   <%= ENV['ELASTICSEARCH_URI'] || 'http://localhost:19200' %>
+    url:   <%= ENV['ELASTICSEARCH_URI'] || 'http://localhost:9200' %>
     index: licence-finder
     type:  sector
 


### PR DESCRIPTION
This has now been updated to point to ES 2.4 on production

https://trello.com/c/iDliRu73/315-licence-finder-on-es-24