### PR TITLE
Use standard buildProject call in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,87 +1,10 @@
 #!/usr/bin/env groovy
 
-JOB_TO_BUILD = 'licencefinder'
-REPOSITORY = 'licence-finder'
-DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
-
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
-  properties([
-    buildDiscarder(
-      logRotator(numToKeepStr: '10')
-      ),
-    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
-    [$class: 'ThrottleJobProperty',
-      categories: [],
-      limitOneJobWithMatchingParams: true,
-      maxConcurrentPerNode: 1,
-      maxConcurrentTotal: 0,
-      paramsToUseForLimit: 'licencefinder',
-      throttleEnabled: true,
-      throttleOption: 'category'],
-    [$class: 'ParametersDefinitionProperty',
-      parameterDefinitions: [
-        [$class: 'BooleanParameterDefinition',
-          name: 'IS_SCHEMA_TEST',
-          defaultValue: false,
-          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
-        [$class: 'StringParameterDefinition',
-          name: 'SCHEMA_BRANCH',
-          defaultValue: DEFAULT_SCHEMA_BRANCH,
-          description: 'The branch of govuk-content-schemas to test against']]
-    ],
-  ])
-
-  try {
-    govuk.initializeParameters([
-      'IS_SCHEMA_TEST': 'false',
-      'SCHEMA_BRANCH': DEFAULT_SCHEMA_BRANCH,
-    ])
-
-    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
-      return
-    }
-
-    stage('Checkout') {
-      checkout scm
-      govuk.cleanupGit()
-      govuk.mergeMasterBranch()
-      govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
-      govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
-    }
-
-    stage('Bundle') {
-      govuk.bundleApp()
-    }
-
-    stage('Linting') {
-      govuk.rubyLinter()
-    }
-
-    stage('Assets') {
-      govuk.precompileAssets()
-    }
-
-    stage('Tests') {
-      govuk.runRakeTask('default')
-    }
-
-    if (env.BRANCH_NAME == 'master') {
-      stage('Push release tag') {
-        govuk.pushTag(REPOSITORY, BRANCH_NAME, 'release_' + BUILD_NUMBER)
-      }
-
-      stage('Deploy to Integration') {
-        govuk.deployIntegration(JOB_TO_BUILD, BRANCH_NAME, 'release', 'deploy')
-      }
-    }
-  } catch (e) {
-    currentBuild.result = 'FAILED'
-    step([$class: 'Mailer',
-          notifyEveryUnstableBuild: true,
-          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
-          sendToIndividuals: true])
-    throw e
-  }
+  govuk.buildProject(
+    sassLint: false,
+    repoName: 'licence-finder'
+  )
 }


### PR DESCRIPTION
Our job in jenkins is 'licencefinder', but our repo on github is
'licence-finder'. The default buildProject used to not understand this
difference which is why we didn't use it.  However, it's now been updated
so that it does understand it and we no longer need our custom version.

Similar to alphagov/contacts-admin#280 - our goal here is to move licencefinder out of [this block in govuk-content-schemas Jenkinsfile](https://github.com/alphagov/govuk-content-schemas/blob/master/Jenkinsfile#L33-L38) because it uses the standard buildProject and will report back to github itself.