### PR TITLE
Remove CSRF Protection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,10 +4,6 @@ class ApplicationController < ActionController::Base
 
   slimmer_template 'wrapper'
 
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  protect_from_forgery
-
 protected
 
   rescue_from GdsApi::TimedOutException, with: :error_503

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,8 @@ module LicenceFinder
 
     # Disable Rack::Cache
     config.action_dispatch.rack_cache = nil
+    config.middleware.delete ActionDispatch::Cookies
+    config.middleware.delete ActionDispatch::Session::CookieStore
+    config.action_controller.allow_forgery_protection = false
   end
 end


### PR DESCRIPTION
Due to sessions being disabled - CSRF protection has never worked. With
Rails 5 this now causes an exception to be thrown because it has changed
how it handles rejected CSRF tokens. This commit removes CSRF protection
to stop this exception being thrown

For more information see: https://github.com/alphagov/frontend/pull/1317