### PR TITLE
Match Dockerfile ruby version to .ruby-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1
+FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y
 
 RUN apt-get install -y build-essential nodejs && apt-get clean


### PR DESCRIPTION
Fix this in advance of us adding a CI check to validate this is true.

https://github.com/alphagov/govuk-puppet/pull/7253