### PR TITLE
Use the contextual breadcrumbs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,7 @@ gem 'sass-rails', '~> 5.0.7'
 gem 'uglifier', '~> 4.1.8'
 
 gem 'govuk_frontend_toolkit', '~> 7.4.2'
-gem 'govuk_navigation_helpers', '~> 9.2.1'
-gem 'govuk_publishing_components', '~> 5.5.6'
+gem 'govuk_publishing_components', '~> 5.6.0'
 
 gem 'govuk-lint', '~> 1.2.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
     nokogumbo (1.5.0)
       nokogiri
     null_logger (0.0.1)
-    parser (2.5.0.4)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     plek (2.1.1)
     poltergeist (1.17.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,9 +120,10 @@ GEM
       activesupport (~> 5.1)
       gds-api-adapters (>= 43.0)
       govuk_ab_testing (~> 2.4)
-    govuk_publishing_components (5.5.6)
+    govuk_publishing_components (5.6.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
+      govuk_navigation_helpers (~> 9.2.1)
       rails (>= 5.0.0.1)
       rake
       rouge
@@ -340,8 +341,7 @@ DEPENDENCIES
   govuk-lint (~> 1.2.1)
   govuk_app_config (~> 1.4.1)
   govuk_frontend_toolkit (~> 7.4.2)
-  govuk_navigation_helpers (~> 9.2.1)
-  govuk_publishing_components (~> 5.5.6)
+  govuk_publishing_components (~> 5.6.0)
   mongoid (~> 6.2.0)
   mongoid_rails_migrations (~> 1.1.0)
   plek (= 2.1.1)

--- a/app/controllers/licence_finder_controller.rb
+++ b/app/controllers/licence_finder_controller.rb
@@ -14,7 +14,7 @@ class LicenceFinderController < ApplicationController
   before_action :extract_and_validate_sector_ids, except: [:sectors, :browse_sector_index, :browse_sector, :browse_sector_child, :browse_sector_grandchild]
   before_action :extract_and_validate_activity_ids, except: [:sectors, :sectors_submit, :activities, :browse_sector_index, :browse_sector, :browse_sector_child, :browse_sector_grandchild]
   before_action :set_expiry
-  before_action :setup_navigation_helpers
+  before_action :setup_content_item
   after_action :add_analytics_headers
 
   def sectors
@@ -128,9 +128,8 @@ protected
     ids.sort
   end
 
-  def setup_navigation_helpers
+  def setup_content_item
     @content_item = Services.content_store.content_item("/licence-finder").to_hash
-    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(@content_item)
     section_name = @content_item.dig("links", "parent", 0, "links", "parent", 0, "title")
     if section_name
       @meta_section = section_name.downcase

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,23 +14,16 @@
   <body class="mainstream">
     <div id="wrapper" class="answer licence-finder <%= yield :page_class %>">
       <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
-      <% unless @sectors %><div class="grid-row"><% end %>
 
-        <main id="content" role="main">
-          <header class="page-header group">
-            <div>
-              <h1>Licence finder</h1>
-            </div>
-          </header>
-          <%= yield %>
-        </main>
+      <main id="content" role="main">
+        <header class="page-header group">
+          <div>
+            <h1>Licence finder</h1>
+          </div>
+        </header>
+        <%= yield %>
+      </main>
 
-      <% unless @sectors %>
-        <div class="related-container">
-          <%= render partial: 'govuk_component/related_items', locals: @navigation_helpers.related_items %>
-        </div>
-      </div>
-      <% end %>
       <%= render 'govuk_publishing_components/components/feedback' %>
     </div>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
   </head>
   <body class="mainstream">
     <div id="wrapper" class="answer licence-finder <%= yield :page_class %>">
-      <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
+      <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item %>
 
       <main id="content" role="main">
         <header class="page-header group">

--- a/spec/integration/browse_sectors_homepage_spec.rb
+++ b/spec/integration/browse_sectors_homepage_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe "Browse sectors via licence finder homepage", type: :request do
     expect(page).to have_css 'ul#sector-navigation'
 
     expect(page).to have_css(shared_component_selector('breadcrumbs'))
-    expect(page).not_to have_css(shared_component_selector('related_items'))
   end
 
   specify "3rd level sectors should be able to be added to the sidebar", js: true do

--- a/spec/integration/browse_sectors_homepage_spec.rb
+++ b/spec/integration/browse_sectors_homepage_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe "Browse sectors via licence finder homepage", type: :request do
 
     expect(page).to have_content @s1.name
     expect(page).to have_css 'ul#sector-navigation'
-
-    expect(page).to have_css(shared_component_selector('breadcrumbs'))
   end
 
   specify "3rd level sectors should be able to be added to the sidebar", js: true do

--- a/spec/integration/browse_sectors_page_spec.rb
+++ b/spec/integration/browse_sectors_page_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe "Sector browse page", type: :request do
     end
 
     expect(page).to have_css(shared_component_selector('breadcrumbs'))
-    expect(page).not_to have_css(shared_component_selector('related_items'))
   end
 
   specify "clicking through drills down the tree" do

--- a/spec/integration/browse_sectors_page_spec.rb
+++ b/spec/integration/browse_sectors_page_spec.rb
@@ -19,8 +19,6 @@ RSpec.describe "Sector browse page", type: :request do
       expect(page).to have_content @s6.name
       expect(page).not_to have_content @s3.name
     end
-
-    expect(page).to have_css(shared_component_selector('breadcrumbs'))
   end
 
   specify "clicking through drills down the tree" do

--- a/spec/integration/licences_page_spec.rb
+++ b/spec/integration/licences_page_spec.rb
@@ -64,8 +64,6 @@ RSpec.describe "Licences page", type: :request do
     expect(page).not_to have_selector(*selector_of_section('upcoming questions'))
 
     expect(page).not_to have_content("No licences")
-
-    expect(page).to have_css(shared_component_selector('breadcrumbs'))
   end
 
   describe "getting licence details from Rummager" do

--- a/spec/integration/licences_page_spec.rb
+++ b/spec/integration/licences_page_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe "Licences page", type: :request do
     expect(page).not_to have_content("No licences")
 
     expect(page).to have_css(shared_component_selector('breadcrumbs'))
-    expect(page).not_to have_css(shared_component_selector('related_items'))
   end
 
   describe "getting licence details from Rummager" do

--- a/spec/integration/sectors_page_spec.rb
+++ b/spec/integration/sectors_page_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe "Sector selection page", type: :request do
         'Where will you be located?'
       ])
     end
-
-    expect(page).to have_css(shared_component_selector('breadcrumbs'))
   end
 
   specify "with sectors selected" do

--- a/spec/integration/sectors_page_spec.rb
+++ b/spec/integration/sectors_page_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe "Sector selection page", type: :request do
     end
 
     expect(page).to have_css(shared_component_selector('breadcrumbs'))
-    expect(page).not_to have_css(shared_component_selector('related_items'))
   end
 
   specify "with sectors selected" do


### PR DESCRIPTION
This PR uses the contextual navigation sidebar and breadcrumbs from the publishing components gem (alphagov/govuk_publishing_components#228). It removes all the logic for what to display where and replaces it with calls to the components.
