### PR TITLE
Add a meta noindex tag to all pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <title><%= content_for?(:page_title) ? yield(:page_title) : "Licence Finder" %> - GOV.UK</title>
     <meta name="description" content="Find out which licences you might need for your activity or business.">
+    <meta name="robots" content="noindex">
     <%= stylesheet_link_tag "licence-finder" %>
     <%= javascript_include_tag 'licence-finder', defer: true %>
     <%= yield :head %>


### PR DESCRIPTION
This does not apply to www.gov.uk/licence-finder, which is rendered by
frontend.

---

[Trello card](https://trello.com/c/UW69iqCW/198-noindex-licence-finder-and-remove-apply-for-a-licence-from-robotstxt)