### PR TITLE
Set rubyLintDiff to false in the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ node {
 
   govuk.buildProject(
     sassLint: false,
+    rubyLintDiff: false,
     repoName: 'licence-finder',
     brakeman: true,
   )


### PR DESCRIPTION
To ensure all the code is valid given the current linting rules.