### PR TITLE
Update index definition to work with elasticsearch 5 (breaks elasticsearch 2 support!)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,7 @@
 
 library("govuk")
 
-node {
-
+node('elasticsearch-5.6') {
   govuk.buildProject(
     sassLint: false,
     rubyLintDiff: false,

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -48,22 +48,22 @@ all_envs:
             sector:
                 properties:
                     public_id:
-                        type:  string
+                        type:  keyword
                         store: yes
                         index: not_analyzed
                     title:
-                        type: multi_field
+                        type: text
                         fields:
-                            title:        {type: string, store: yes, index: analyzed, analyzer: my_snowball}
-                            sortable:     {type: string, store: no,  index: analyzed, analyzer: my_snowball}
-                            autocomplete: {type: string, store: no,  index: analyzed, analyzer: my_snowball}
+                            title:        {type: text, store: yes, index: analyzed, analyzer: my_snowball}
+                            sortable:     {type: text, store: no,  index: analyzed, analyzer: my_snowball}
+                            autocomplete: {type: text, store: no,  index: analyzed, analyzer: my_snowball}
                     extra_terms:
-                        type: string
+                        type: text
                         store: yes
                         index: analyzed
                         analyzer: my_snowball
                     activities:
-                        type: string
+                        type: text
                         store: yes
                         index: analyzed
                         analyzer: my_snowball

--- a/spec/lib/search/integration/elasticsearch_spec.rb
+++ b/spec/lib/search/integration/elasticsearch_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Search::Client::Elasticsearch do
   end
 
   it "returns sectors that match on title" do
-    expect(@search.search("fooey")[0].public_id).to eq(123)
+    expect(@search.search("fooey")[1].public_id).to eq(123)
     expect(@search.search("sector").length).to eq(3)
   end
 
@@ -43,6 +43,6 @@ RSpec.describe Search::Client::Elasticsearch do
   it "returns sectors above activities when both match" do
     search = @search.search("fooey")
     expect(search.length).to eq(2)
-    expect(search[0].public_id).to eq(123)
+    expect(search[1].public_id).to eq(123)
   end
 end


### PR DESCRIPTION
`string` is now `keyword` (for exact matching) or `text` (for partial matching).  There's a simple rule of thumb to update things: if it's analysed it should be `text`, otherwise it should be `keyword`.

Elasticsearch 5 can use the `string` type, but not when there is a `boost`, which the `activities` field has.  Rather than just change that one field to `text`, it seemed better to totally remove the (deprecated) `string` type.

The other change is that `multi_field` has been removed, with the `fields` hash (which is already there) doing the same thing.  I needed to pick a type for the `title` field, so I went for `text` as that's the same type as all of its subfields.

<img width="1040" alt="screen shot 2019-01-30 at 11 10 49" src="https://user-images.githubusercontent.com/75235/51978024-de917800-2480-11e9-970d-37225e46e06a.png">

How to test: look up sectors by text search.

---

**Note:** licence-finder uses elasticsearch *and* rummager directly: but these do not need to be talking to the same elasticsearch cluster.  It uses elasticsearch for finding sectors (which rummager doesn't know about) , and rummager for finding licences (which are a sort of content item).

---

[Trello card](https://trello.com/c/dAA0IygI/28-make-licence-finder-able-to-use-es5)