### PR TITLE
Add all JavaScript dependencies from govuk_publishing_components

### DIFF
--- a/app/assets/javascripts/licence-finder.js
+++ b/app/assets/javascripts/licence-finder.js
@@ -1,4 +1,4 @@
-//= require govuk_publishing_components/components/feedback
+//= require govuk_publishing_components/all_components
 
 /*globals $ */
 /*jslint


### PR DESCRIPTION
This is one of the few remaining apps that don't require all scripts form govuk_publishing_components.