### PR TITLE
Make schema definition ES6 compatible

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -50,21 +50,21 @@ all_envs:
                     public_id:
                         type:  keyword
                         store: yes
-                        index: not_analyzed
+                        index: true
                     title:
                         type: text
                         fields:
-                            title:        {type: text, store: yes, index: analyzed, analyzer: my_snowball}
-                            sortable:     {type: text, store: no,  index: analyzed, analyzer: my_snowball}
-                            autocomplete: {type: text, store: no,  index: analyzed, analyzer: my_snowball}
+                            title:        {type: text, store: yes, index: true, analyzer: my_snowball}
+                            sortable:     {type: text, store: no,  index: true, analyzer: my_snowball}
+                            autocomplete: {type: text, store: no,  index: true, analyzer: my_snowball}
                     extra_terms:
                         type: text
                         store: yes
-                        index: analyzed
+                        index: true
                         analyzer: my_snowball
                     activities:
                         type: text
                         store: yes
-                        index: analyzed
+                        index: true
                         analyzer: my_snowball
                         boost: 0.7


### PR DESCRIPTION
When moving to ES5, we changed the fields from "string" fields to
"text" and "keyword" fields.  This made all of the "analyzed" /
"not_analyzed" settings redundant, but we didn't realise it at the
time: https://www.elastic.co/blog/strings-are-dead-long-live-strings

ES6 removes the "analyzed" / "not_analyzed" options, so we should make
the suggested change.

---

[Trello card](https://trello.com/c/m9tBhTvd/720-make-licence-finder-es6-compatible-if-its-not-already-%F0%9F%8D%90)