### PR TITLE
Document how to run a local licence-finder against the live site

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ bowl licencefinder
 
 If you are using the GDS development virtual machine then the application will be available on the host at http://licencefinder.dev.gov.uk/licence-finder
 
+#### Without using the VM
+
+Licence Finder can be run against the live Content Store and Search API, however it needs local instances of Elasticsearch and MongoDB.
+
+You can use docker to create these:
+
+```
+docker run -d -p 9200:9200 -e "discovery.type=single-node" --name licence-finder-elasticsearch docker.elastic.co/elasticsearch/elasticsearch:6.8.0
+docker run -d -p 27017-27019:27017-27019 --name licence-finder-mongodb mongo:latest
+```
+
+Import the data and start the application:
+
+```
+export ELASTICSEARCH_URI='http://localhost:9200/'
+export MONGODB_URI='mongodb://localhost/'
+bundle exec rake data_import:all
+bundle exec rake search:index
+./startup.sh --live
+```
+
+The application will be available at http://localhost:3014
+
 ### Publishing to GOV.UK
 
 - `bundle exec rake publishing_api:publish` will send the licence finder pages to the publishing-api.

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
 
 bundle install
-bundle exec rails s -p 3014
+
+if [[ $1 == "--live" ]] ; then
+  echo "[Note] Even when using the live content-store and search-api"
+  echo "licence-finder still needs a local instance of elasticsearch and"
+  echo "mongodb."
+
+  GOVUK_APP_DOMAIN=www.gov.uk \
+  GOVUK_WEBSITE_ROOT=https://www.gov.uk \
+  PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.gov.uk/api} \
+  PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
+  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
+  bundle exec rails s -p 3014
+else
+  bundle exec rails s -p 3014
+fi


### PR DESCRIPTION
We have this for a lot of other frontend apps.