### PR TITLE
Use ES6 (port 9001) for development and testing

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,10 +1,10 @@
 development:
-    url:   <%= ENV['ELASTICSEARCH_URI'] || 'http://localhost:9200' %>
+    url:   <%= ENV['ELASTICSEARCH_URI'] || 'http://localhost:9201' %>
     index: licence-finder-development
     type:  sector
 
 test:
-    url:   <%= ENV['ELASTICSEARCH_URI'] || 'http://localhost:9200' %>
+    url:   <%= ENV['ELASTICSEARCH_URI'] || 'http://localhost:9201' %>
     index: licence-finder-test
     type:  sector
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/NrbcW7ly/807-switch-licence-finder-over-to-es6-in-production)