### PR TITLE
Revert "Bump elasticsearch from 7.0.0 to 7.1.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,12 +69,12 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    elasticsearch (7.1.0)
-      elasticsearch-api (= 7.1.0)
-      elasticsearch-transport (= 7.1.0)
-    elasticsearch-api (7.1.0)
+    elasticsearch (7.0.0)
+      elasticsearch-api (= 7.0.0)
+      elasticsearch-transport (= 7.0.0)
+    elasticsearch-api (7.0.0)
       multi_json
-    elasticsearch-transport (7.1.0)
+    elasticsearch-transport (7.0.0)
       faraday
       multi_json
     erubi (1.8.0)


### PR DESCRIPTION
Reverts alphagov/licence-finder#531

We think this broke a deploy.