### PR TITLE
Remove Nursing agency registration (Wales) licence

### DIFF
--- a/data/licences.csv
+++ b/data/licences.csv
@@ -3553,7 +3553,6 @@
 "1000434","Physiotherapy","167","Offer treatments involving lasers or intense pulsed light systems","1074535201","Laser or intense pulsed light treatment registration (England &amp; Wales)","Healthcare and medicines","1","0","1","0","0"
 "1000440","Hospitals","167","Offer treatments involving lasers or intense pulsed light systems","1084062241","Laser or intense pulsed light treatment licence (Northern Ireland)","Healthcare and medicines","0","0","0","1","0"
 "1000459","Beautician services","167","Offer treatments involving lasers or intense pulsed light systems","1084062241","Laser or intense pulsed light treatment licence (Northern Ireland)","Healthcare and medicines","0","0","0","1","0"
-"1000352","Recruitment agencies and personnel supply","175","Run a nursing agency","1074535400","Nursing agency registration (Wales)","Social and welfare","0","0","1","0","0"
 "1000504","Betting shop operation","180","Provide betting facilities at a track or sports stadium","1077580454","Track betting licence (Northern Ireland)","Hospitality, leisure and entertainment","0","0","0","1","0"
 "1000328","Patent and copyright agent services","188","Make copies of extracts from books, magazines or journals for business use","1074535528","Copyright Licensing Agency licence (All UK)","Copyright","1","1","1","1","0"
 "1000335","Health and safety consultancy","188","Make copies of extracts from books, magazines or journals for business use","1074535528","Copyright Licensing Agency licence (All UK)","Copyright","1","1","1","1","0"


### PR DESCRIPTION
As per this Zendesk ticket https://govuk.zendesk.com/agent/tickets/3715638 the
law has changed in Wales and there is no longer a need for nursing agencies to
register with Care and Social Services Inspectorate Wales, so this licence
needs to be removed from Licence Finder.