### PR TITLE
Change CI agent requirement to "elasticsearch-6.7"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 library("govuk")
 
-node('elasticsearch-5.6') {
+node('elasticsearch-6.7') {
   govuk.buildProject(
     sassLint: false,
     rubyLintDiff: false,


### PR DESCRIPTION
The "elasticsearch-5.6" label is going away shortly.