### PR TITLE
Fix dev/test elasticsearch port

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,10 +1,10 @@
 development:
-    url:   <%= ENV['ELASTICSEARCH_URI'] || 'http://localhost:9201' %>
+    url:   <%= ENV['ELASTICSEARCH_URI'] || 'http://localhost:9200' %>
     index: licence-finder-development
     type:  sector
 
 test:
-    url:   <%= ENV['ELASTICSEARCH_URI'] || 'http://localhost:9201' %>
+    url:   <%= ENV['ELASTICSEARCH_URI'] || 'http://localhost:9200' %>
     index: licence-finder-test
     type:  sector
 


### PR DESCRIPTION
We had ES5 on 9200 and ES6 on 9201.  When ES5 went away ES6 moved to
9200.