### PR TITLE
Rescue 403 errors from content store

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,12 @@ class ApplicationController < ActionController::Base
 
 protected
 
+  rescue_from GdsApi::HTTPForbidden, with: :error_403
   rescue_from GdsApi::TimedOutException, with: :error_503
+
+  def error_403
+    render status: :forbidden, plain: "403 forbidden"
+  end
 
   def error_503(exception = nil)
     error(503, exception)

--- a/spec/controllers/licence_finder_controller_spec.rb
+++ b/spec/controllers/licence_finder_controller_spec.rb
@@ -125,6 +125,16 @@ RSpec.describe LicenceFinderController, type: :controller do
       end
     end
 
+    context "when content store returns forbidden response" do
+      it "returns a 403 status code" do
+        stub_request(:get, "#{Plek.find('content-store')}/content/licence-finder").
+          to_return(status: 403, headers: {})
+
+        get :activities, params: { sectors: "1234_2345_3456" }
+        expect(response).to be_forbidden
+      end
+    end
+
     context "with no valid sectors selected" do
       it "returns a 404 status code" do
         get :activities


### PR DESCRIPTION
Trello: https://trello.com/c/hRJ5dViF/173-unauthenticated-user-accessing-a-licence-finder-page-with-step-by-step-token-is-directed-to-sign-on
Follows on from: [RFC 113: Expanding draft access for unauthenticated users to allow multi-page fact checks](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-113-expanding-draft-access-for-unauthenticated-users.md)

## What's changed and why?

At the moment licence-finder is throwing a 500 when it receives
an error code it doesn't recognise from content-store. That means
that users are shown a "Problem has occurred" page.

We need to handle this error properly so that in the case of a
403, the user will be properly routed to signon and asked to login
if there is any form of access limiting on the content item (e.g.
hosted on draft stack, access limited to organisation)