### PR TITLE
Add using env var for test mongodb

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -10,7 +10,7 @@ development:
 test:
   clients:
     default:
-      uri: <%= ENV["MONGODB_URI"] || "mongodb://localhost/licence_finder_test" %>
+      uri: <%= ENV["TEST_MONGODB_URI"] || "mongodb://localhost/licence_finder_test" %>
       options:
         write:
           w: 1


### PR DESCRIPTION
So that we avoid the risk of polluting databases locally when running
in Docker.

See https://github.com/alphagov/govuk-docker/pull/214