### PR TITLE
Migrate from `govuk-lint` to `rubocop-govuk`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.3
+
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    # - config/rails.yml # add this once we're ready to add Rails cops

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'uglifier', '~> 4.2.0'
 gem 'govuk_frontend_toolkit', '~> 9.0.0'
 gem 'govuk_publishing_components', '~> 17.21.0'
 
-gem 'govuk-lint', '~> 4.2.0'
+gem 'rubocop-govuk'
 
 group :development, :test do
   gem 'database_cleaner', '~> 1.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,11 +96,6 @@ GEM
       activesupport (>= 4.2.0)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.2.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.12.0)
@@ -260,6 +255,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -288,8 +287,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -348,7 +345,6 @@ DEPENDENCIES
   factory_bot_rails
   gds-api-adapters (~> 61.0)
   govuk-content-schema-test-helpers
-  govuk-lint (~> 4.2.0)
   govuk_app_config (~> 2.0.1)
   govuk_frontend_toolkit (~> 9.0.0)
   govuk_publishing_components (~> 17.21.0)
@@ -360,6 +356,7 @@ DEPENDENCIES
   rails (= 5.2.3)
   rails-controller-testing
   rspec-rails (~> 3.9.0)
+  rubocop-govuk
   sass-rails (~> 5.0.7)
   slimmer (= 13.2.0)
   uglifier (~> 4.2.0)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
 desc "Run govuk-lint with similar params to CI"
 task "lint" do
-  sh "bundle exec govuk-lint-ruby --format clang app spec lib"
+  sh "bundle exec rubocop --format clang app spec lib"
 end


### PR DESCRIPTION
I followed [this doc page](https://docs.publishing.service.gov.uk/manual/migrate-from-govuk-lint.html)
for this migration.