### PR TITLE
Remove legacy colours flag

### DIFF
--- a/app/assets/stylesheets/licence-finder.scss
+++ b/app/assets/stylesheets/licence-finder.scss
@@ -1,4 +1,3 @@
-$govuk-use-legacy-palette: true;
 $govuk-typography-use-rem: false;
 
 @import "govuk_publishing_components/all_components";


### PR DESCRIPTION
https://trello.com/c/cjrsYT8M/120-switch-to-new-colours-in-licence-finder

Switches to new colours by removing the flag setting the legacy palette.

### Before
![Screenshot 2020-01-09 at 11 12 23](https://user-images.githubusercontent.com/31649453/72064643-3614a680-32d4-11ea-8cbf-af3b6fb60022.png)
### After
![Screenshot 2020-01-09 at 11 12 01](https://user-images.githubusercontent.com/31649453/72064640-3614a680-32d4-11ea-9e3e-9ce5e3cc1219.png)

