### PR TITLE
Remove a dependency on static

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # licence-finder
 
+Licence finder provides the pages that follow https://www.gov.uk/licence-finder (which is served by `frontend`), specifically starting at https://www.gov.uk/licence-finder/sectors.
+
+## Local setup
+
 To get set up with Licence Finder, first make sure you're up to date with puppet.
 
 Load the data into MongoDB

--- a/app/assets/stylesheets/licence-finder.scss
+++ b/app/assets/stylesheets/licence-finder.scss
@@ -25,11 +25,6 @@ a:link {
   }
 }
 
-
-.current-question h2 {
-  width: 100%;
-}
-
 #search-sectors {
   margin-left: 0;
 }

--- a/app/views/licence_finder/_completed_questions.html.erb
+++ b/app/views/licence_finder/_completed_questions.html.erb
@@ -4,9 +4,12 @@
     <ol>
       <%- @completed_questions.each_with_index do |question_details, index| -%>
         <li class="done">
-          <h3 class="question">
-            <span class="question-number"><%= index + 1 %></span><%= question_details[0] %>
-          </h3>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "#{index + 1}. #{question_details[0]}",
+            padding: true,
+            font_size: 19,
+            heading_level: 3
+          } %>          
           <div class="answer multiple">
             <ul>
               <% question_details[1].each do |answer| %>

--- a/app/views/licence_finder/_current_question.html.erb
+++ b/app/views/licence_finder/_current_question.html.erb
@@ -1,9 +1,10 @@
 <div class="step current">
-  <div class="current-question group">
-    <h2>
-      <span class="question-number"><%= @current_question_number %> </span><%= @current_question %>
-    </h2>
+  <div class="group">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "#{@current_question_number}. #{@current_question}",
+      padding: true,
+      font_size: 19
+    } %>
     <%= body %>
   </div>
 </div>
-

--- a/app/views/licence_finder/_upcoming_questions.html.erb
+++ b/app/views/licence_finder/_upcoming_questions.html.erb
@@ -3,9 +3,12 @@
     <ol>
       <%- @upcoming_questions.each_with_index do |question, index| %>
         <li class="upcoming">
-          <h3 class="question">
-            <span class="question-number"><%= @current_question_number + index + 1 %></span><%= question %>
-          </h3>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "#{@current_question_number + index + 1}. #{question}",
+            padding: true,
+            font_size: 19,
+            heading_level: 3
+          } %>
         </li>
       <%- end -%>
     </ol>

--- a/app/views/licence_finder/sectors.html.erb
+++ b/app/views/licence_finder/sectors.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "What is your activity or business? - Licence Finder" %>
 
 <div class="step current">
-  <div class="current-question group">
+  <div class="group">
     <div class="search-container" role="search">
       <%= form_tag sectors_path, method: :get do %>
         <%= hidden_field_tag "sectors", params[:sectors], id: "hidden-sectors" %>

--- a/spec/integration/activities_page_spec.rb
+++ b/spec/integration/activities_page_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe "Activity selection page", type: :request do
     visit licence_finder_url_for("activities", [@s1, @s3])
 
     within_section "completed questions" do
-      expect(page.all(:xpath, ".//h3[contains(@class, 'question')]/text()").map(&:text).map(&:strip).reject(&:blank?)).to eq([
-        "What is your activity or business?",
+      expect(page.all(:xpath, ".//h3[contains(@class, 'gem-c-heading')]/text()").map(&:text).map(&:strip).reject(&:blank?)).to eq([
+        "1. What is your activity or business?",
       ])
     end
     within_section "completed question 1" do
@@ -42,8 +42,8 @@ RSpec.describe "Activity selection page", type: :request do
     end
 
     within_section "upcoming questions" do
-      expect(page.all(:xpath, ".//h3[contains(@class, 'question')]/text()").map(&:text).map(&:strip).reject(&:blank?)).to eq([
-        "Where will you be located?",
+      expect(page.all(:xpath, ".//h3[contains(@class, 'gem-c-heading')]/text()").map(&:text).map(&:strip).reject(&:blank?)).to eq([
+        "3. Where will you be located?",
       ])
     end
 

--- a/spec/integration/business_location_page_spec.rb
+++ b/spec/integration/business_location_page_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe "Business location page", type: :request do
     visit licence_finder_url_for("location", [@s1, @s2], [@a1, @a2])
 
     within_section "completed questions" do
-      expect(page.all(:xpath, ".//h3[contains(@class, 'question')]/text()").map(&:text).map(&:strip).reject(&:blank?)).to eq([
-        "What is your activity or business?",
-        "What would you like to do?",
+      expect(page.all(:xpath, ".//h3[contains(@class, 'gem-c-heading')]/text()").map(&:text).map(&:strip).reject(&:blank?)).to eq([
+        "1. What is your activity or business?",
+        "2. What would you like to do?",
       ])
     end
     within_section "completed question 1" do

--- a/spec/integration/licences_page_spec.rb
+++ b/spec/integration/licences_page_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe "Licences page", type: :request do
     visit licence_finder_url_for("licences", [@s1], [@a1], "scotland")
 
     within_section "completed questions" do
-      expect(page.all(:xpath, ".//h3[contains(@class, 'question')]/text()").map(&:text).map(&:strip).reject(&:blank?)).to eq([
-        "What is your activity or business?",
-        "What would you like to do?",
-        "Where will you be located?",
+      expect(page.all(:xpath, ".//h3[contains(@class, 'gem-c-heading')]/text()").map(&:text).map(&:strip).reject(&:blank?)).to eq([
+        "1. What is your activity or business?",
+        "2. What would you like to do?",
+        "3. Where will you be located?",
       ])
     end
     within_section "completed question 1" do

--- a/spec/integration/sectors_page_spec.rb
+++ b/spec/integration/sectors_page_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe "Sector selection page", type: :request do
     end
 
     within_section "upcoming questions" do
-      expect(page.all(:xpath, ".//h3[contains(@class, 'question')]/text()").map(&:text).map(&:strip).reject(&:blank?)).to eq([
-        "What would you like to do?",
-        "Where will you be located?",
+      expect(page.all(:xpath, ".//h3[contains(@class, 'gem-c-heading')]/text()").map(&:text).map(&:strip).reject(&:blank?)).to eq([
+        "2. What would you like to do?",
+        "3. Where will you be located?",
       ])
     end
   end

--- a/spec/support/section_helper.rb
+++ b/spec/support/section_helper.rb
@@ -4,10 +4,11 @@ module SectionHelper
     when "completed questions"
       [:css, ".done-questions"]
     when /^completed question (\d+)$/
-      [:xpath, "//*[contains(@class, 'done-questions')]//li[contains(@class, 'done')][.//*[contains(@class, 'question-number')][text() = '#{$1}']]"]
+      # [:xpath, "//*[contains(@class, 'done-questions')]//li[contains(@class, 'done')][.//*[contains(@class, 'gem-c-heading')][text() = '#{$1}']]"]
+      [:xpath, "//*[contains(@class, 'done-questions')]//li[contains(@class, 'done')][.//*[contains(@class, 'gem-c-heading')][starts-with(text(), '#{$1}.')]]"]
 
     when "current question"
-      [:css, ".current-question"]
+      [:css, ".step.current"]
 
     when "upcoming questions"
       [:css, ".upcoming-questions"]


### PR DESCRIPTION
## What

Remove instances of the `.current-question` class. This comes from static and provides styling, but we're trying to [remove it](https://github.com/alphagov/static/pull/2025).

## Why

Should be using components and govuk-frontend for styling. Note that this PR does not dramatically update this app to use components/govuk-frontend (although that needs doing).

## Visual changes

The documentation's a bit scarce, but a licence-finder journey appears to be as follows:

1. https://www.gov.uk/licence-finder (served by `frontend`)
1. https://www.gov.uk/licence-finder/sectors (`licence-finder` from here on in)
1. https://www.gov.uk/licence-finder/sectors?utf8=%E2%9C%93&sectors=&q=volunteer
1. https://www.gov.uk/licence-finder/activities?sectors=22_29
1. https://www.gov.uk/licence-finder/location?sectors=22_29&activities=37
1. https://www.gov.uk/licence-finder/licences?activities=37&location=england&sectors=22_29 (finish)

Only affected pages are detailed below.

### Page 2

Slight removal of space at the top of the page.

Before | After
------- | -------
![Screenshot 2020-02-05 at 12 10 17](https://user-images.githubusercontent.com/861310/73840650-866a2000-4810-11ea-8816-493de2aeeb0b.png) | ![Screenshot 2020-02-05 at 12 10 23](https://user-images.githubusercontent.com/861310/73840666-8c600100-4810-11ea-885a-9b727e3c1c63.png)

### Page 4

Heading ('What would you like to do?') updated to use a component. Previously had a span in to style the number differently, have added a `.` in the text to delineate them.

(note that the 'after' shot doesn't have all the data, because this is running on my local dev env)

Before | After
------- | -------
![Screenshot 2020-02-05 at 12 12 51](https://user-images.githubusercontent.com/861310/73840800-ef519800-4810-11ea-9450-b853eadba398.png) | ![Screenshot 2020-02-05 at 12 12 56](https://user-images.githubusercontent.com/861310/73840813-f5e00f80-4810-11ea-8d64-88b0af49ea77.png)
