### PR TITLE
Make question text formatting consistent

### DIFF
--- a/app/views/licence_finder/sectors.html.erb
+++ b/app/views/licence_finder/sectors.html.erb
@@ -7,7 +7,7 @@
         <%= hidden_field_tag "sectors", params[:sectors], id: "hidden-sectors" %>
 
         <%= render "govuk_publishing_components/components/input", {
-            label: { text: "#{@current_question_number} #{@current_question}" },
+            label: { text: "#{@current_question_number}. #{@current_question}" },
             name: "q",
             id: "search-sectors",
             heading_size: "s"


### PR DESCRIPTION
- recently made a change to have numbers in questions not in a separate span and styled differently but to be followed by a '.'
- missed the first question, this change corrects that

Before:

<img width="567" alt="Screenshot 2020-02-07 at 09 33 23" src="https://user-images.githubusercontent.com/861310/74017909-ec7bb200-498c-11ea-8f38-7a235762d97b.png">

After:

<img width="530" alt="Screenshot 2020-02-07 at 09 33 29" src="https://user-images.githubusercontent.com/861310/74017928-f1406600-498c-11ea-9bc7-d2c216bf567e.png">
