### PR TITLE
Remove .button references

### DIFF
--- a/app/assets/stylesheets/licence-finder.scss
+++ b/app/assets/stylesheets/licence-finder.scss
@@ -90,10 +90,6 @@ a.add {
     @include govuk-font(19);
   }
 
-  .button {
-    display: inline-block;
-  }
-
   ul {
     margin-top: 0.75em;
     margin-bottom: 0.75em;
@@ -230,10 +226,6 @@ a.add {
   ul ul li {
     padding: 0 0.25em;
   }
-}
-
-.search-container .button {
-  margin-left: 0.5em;
 }
 
 .find-location-for-service {


### PR DESCRIPTION
The `.button` style isn't use in this app anymore and we're removing it from static, so these lines are redundant. 

Note that `.button-container` is in use, particularly by some JS in this app, so we're not removing that.