### PR TITLE
Add govuk-compatibility-govuktemplate to remove font duplication.

### DIFF
--- a/app/assets/stylesheets/licence-finder.scss
+++ b/app/assets/stylesheets/licence-finder.scss
@@ -1,4 +1,5 @@
 $govuk-typography-use-rem: false;
+$govuk-compatibility-govuktemplate: true;
 
 @import "govuk_publishing_components/all_components";
 


### PR DESCRIPTION
While implementing some web performance monitoring I noticed that we are downloading both v1 and v2 fonts for pages using this app. I believe this is because we are missing `$govuk-compatibility-govuktemplate: true;`

![licence-waterfall](https://user-images.githubusercontent.com/1223960/81922475-13710200-95d4-11ea-8f6c-0e48aea53339.png)

This PR should hopefully stop the v2 fonts and bring the weight down to 120KB instead of 184KB. Full WebPageTest results can be seen [here](https://www.webpagetest.org/result/200514_SM_baf869d96f94cdae1107cf00f355696f/1/details/#waterfall_view_step1)
 