### PR TITLE
Run RuboCop as part of `bundle exec rake` defaults …

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
 
-task default: [:spec]
+task default: %i[spec lint]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Linting"
+task lint: :environment do
+  sh "bundle exec rubocop --format clang"
+end


### PR DESCRIPTION
- This is a prerequisite for being able to move more of our apps to
  GitHub Actions. We want one single step bundle exec rake that runs
  everything. This ensures parity between local dev and what CI runs
  (something that we don't always have now).

https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks