### PR TITLE
Switch asset host to www

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,12 @@ module LicenceFinder
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    config.assets.prefix = "/licencefinder" # this has to match the path configured in puppet and deploy scripts.
+    config.assets.prefix = "/assets/licencefinder"
+
+    # allow overriding the asset host with an enironment variable, useful for
+    # when router is proxying to this app but asset proxying isn't set up.
+    config.asset_host = ENV["ASSET_HOST"]
+
     config.assets.precompile += %w[
       application.css
       print.css

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,11 +57,6 @@ Rails.application.configure do
   # Use a different cache store in production
   # config.cache_store = :mem_cache_store
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server
-  config.action_controller.asset_host = ENV["GOVUK_ASSET_HOST"]
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
-
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/initializers/slimmer.rb
+++ b/config/initializers/slimmer.rb
@@ -1,11 +1,3 @@
 Rails.application.configure do
   config.slimmer.logger = Rails.logger
-
-  if Rails.env.production?
-    config.slimmer.use_cache = true
-  end
-
-  if Rails.env.development?
-    config.slimmer.asset_host = ENV["STATIC_DEV"] || "http://static.dev.gov.uk"
-  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This allows asset host to be set by ASSET_HOST env var rather than
GOVUK_ASSET_HOST. This is in preparation for the assets of this app
changing hostname from assets.publishing.service.gov.uk to
www.gov.uk.

As part of this change the path to assets is changed to
/assets/licencefinder

The expectation is that this env var will only be set in dev
environments when proxying isn't set up for router.