### PR TITLE
Create test-dependencies.js to replace live static assets

### DIFF
--- a/app/assets/javascripts/test-dependencies.js
+++ b/app/assets/javascripts/test-dependencies.js
@@ -1,0 +1,3 @@
+// This file contains dependencies that are only needed when running in a test
+// environment. In the dev and live environment these are provided by static.
+//= require govuk_publishing_components/dependencies

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <meta name="robots" content="noindex">
     <%= stylesheet_link_tag "application" %>
     <%= stylesheet_link_tag "print.css", :media => "print" %>
+    <%= javascript_include_tag 'test-dependencies' if Rails.env.test? %>
     <%= javascript_include_tag 'application', defer: true %>
     <%= yield :head %>
     <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,7 @@ module LicenceFinder
       application.css
       print.css
       application.js
+      test-dependencies.js
     ]
 
     # Disable Rack::Cache


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

The tests for this app were failing after GOV.UK's assets switched from
the assets hostname to www. This was because slimmer was actually
embedding links to production GOV.UK assets which were symlinked to the
latest ones. Once the assets changed path then the tests broke.

Since it is good practice for tests to be isolated I've created a
test-dependencies.js file which loads in the basic slimmer dependencies
from govuk_publishing_components. This has the advantage that this test
suite no longer has external network requirement, but does have the
disadvantage that the JS isn't the same. This trade-off seems reasonable
since there was never anything particularly realistic about the slimmer
test template [1] and it's mostly luck that it matches production.

[1]: https://github.com/alphagov/slimmer/blob/master/lib/slimmer/test_templates/wrapper.html