### PR TITLE
Eager and auto load files in lib directory 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 ruby File.read(".ruby-version").strip
 
-gem "elasticsearch"
+gem "elasticsearch", "~> 6"
 gem "gds-api-adapters", "~> 67.0"
 gem "govuk_app_config", "~> 2.2.0"
 gem "govuk_frontend_toolkit", "~> 9.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,13 +67,13 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    elasticsearch (7.0.0)
-      elasticsearch-api (= 7.0.0)
-      elasticsearch-transport (= 7.0.0)
-    elasticsearch-api (7.0.0)
+    elasticsearch (6.8.2)
+      elasticsearch-api (= 6.8.2)
+      elasticsearch-transport (= 6.8.2)
+    elasticsearch-api (6.8.2)
       multi_json
-    elasticsearch-transport (7.0.0)
-      faraday
+    elasticsearch-transport (6.8.2)
+      faraday (~> 1)
       multi_json
     erubi (1.9.0)
     execjs (2.7.0)
@@ -163,7 +163,7 @@ GEM
       mongoid (>= 4.0.0)
       rails (>= 4.2.0)
       railties (>= 4.2.0)
-    multi_json (1.13.1)
+    multi_json (1.14.1)
     multipart-post (2.1.1)
     netrc (0.11.0)
     nio4r (2.5.2)
@@ -336,7 +336,7 @@ PLATFORMS
 
 DEPENDENCIES
   database_cleaner (~> 1.8.5)
-  elasticsearch
+  elasticsearch (~> 6)
   factory_bot_rails
   gds-api-adapters (~> 67.0)
   govuk-content-schema-test-helpers

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,5 +1,3 @@
-require "public_id"
-
 class Activity
   include Mongoid::Document
   include PublicId

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -1,5 +1,3 @@
-require "public_id"
-
 class Sector
   include Mongoid::Document
   include PublicId

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,9 @@ module LicenceFinder
 
     config.assets.prefix = "/assets/licencefinder"
 
+    config.eager_load_paths << Rails.root.join("lib")
+    config.autoload_paths << Rails.root.join("lib")
+
     # allow overriding the asset host with an enironment variable, useful for
     # when router is proxying to this app but asset proxying isn't set up.
     config.asset_host = ENV["ASSET_HOST"]

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1,4 +1,3 @@
-require "search/client/elasticsearch"
 require "erb"
 
 class Search

--- a/lib/search/client/elasticsearch.rb
+++ b/lib/search/client/elasticsearch.rb
@@ -1,7 +1,3 @@
-require "search/client"
-require "search/client/search_result"
-require "elasticsearch"
-
 class Search
   class Client
     class Elasticsearch < Search::Client

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -1,6 +1,3 @@
-require "data_importer"
-require "licence_data_migrator"
-
 desc "Import all data from the CSV files"
 task data_import: ["data_import:sectors", "data_import:activities", "data_import:licences"]
 

--- a/lib/tasks/licence_migrate.rake
+++ b/lib/tasks/licence_migrate.rake
@@ -1,5 +1,3 @@
-require "licence_data_migrator"
-
 desc "Import all data from the CSV files"
 task licence_migrate: ["licence_migrate:all"]
 


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This is done off the back of a short incident that occurred today where
the application started erroring due to a constant (Search) being
unavailable.

This was caused by https://github.com/alphagov/licence-finder/commit/db8c489b2bae147774f79826fc6ea1d3b4b21818
where search used to be set-up by a strange global variable via an
initializer file. Once this was changed search was no longer available
unless the file was required (as was the case in the test environment)
and would error.

To simplify the differences between test and production I've set up all
of the lib files to be eager and auto loaded so that the
dev/test/production files are the same. As part of this I've removed the
various require statements as these are no longer needed.