### PR TITLE
Use individual component JS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,6 @@
-//= require govuk_publishing_components/all_components
+//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/feedback
 
 /*globals $ */
 /*jslint


### PR DESCRIPTION
Update licence-finder to import the Javascript for only the components it is using, instead of all components, as [documented here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-sass-for-individual-components) and [here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-javascript-for-individual-components).

## Filesize comparison

<img width="435" alt="Screenshot 2020-07-16 at 16 21 51" src="https://user-images.githubusercontent.com/861310/87690085-e8945d00-c780-11ea-913e-5a87773de81b.png">

JS before: **487 KB** 

<img width="435" alt="Screenshot 2020-07-16 at 16 22 10" src="https://user-images.githubusercontent.com/861310/87690116-f1852e80-c780-11ea-962f-babea7b3efa0.png">

JS after: **159 KB** 


Trello card: https://trello.com/c/GWttlBxs/228-upgrade-applications-to-use-individual-component-sass

