### PR TITLE
Pin Elasticsearch to 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby File.read(".ruby-version").strip
 
 gem "rails", "6.0.3.2"
 
-gem "elasticsearch"
+gem "elasticsearch", "~> 6"
 gem "gds-api-adapters"
 gem "govuk_app_config"
 gem "govuk_frontend_toolkit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,12 +80,12 @@ GEM
     diff-lcs (1.4.4)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    elasticsearch (7.8.0)
-      elasticsearch-api (= 7.8.0)
-      elasticsearch-transport (= 7.8.0)
-    elasticsearch-api (7.8.0)
+    elasticsearch (6.8.2)
+      elasticsearch-api (= 6.8.2)
+      elasticsearch-transport (= 6.8.2)
+    elasticsearch-api (6.8.2)
       multi_json
-    elasticsearch-transport (7.8.0)
+    elasticsearch-transport (6.8.2)
       faraday (~> 1)
       multi_json
     erubi (1.9.0)
@@ -355,7 +355,7 @@ PLATFORMS
 
 DEPENDENCIES
   database_cleaner
-  elasticsearch
+  elasticsearch (~> 6)
   factory_bot_rails
   gds-api-adapters
   govuk-content-schema-test-helpers


### PR DESCRIPTION
It was updated to 7 in the Rails 6 upgrade, but it fails in production

See https://github.com/alphagov/licence-finder/commit/23476adb977c489aa9cd7fdb701b937bd101f6c3