### PR TITLE
Upgrade to ruby 2.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-ruby File.read(".ruby-version").strip
-
 gem "rails", "6.0.3.3"
 
 gem "elasticsearch", "~> 6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,8 +376,5 @@ DEPENDENCIES
   uglifier
   webmock
 
-RUBY VERSION
-   ruby 2.6.6
-
 BUNDLED WITH
    1.17.3

--- a/app/models/licence_facade.rb
+++ b/app/models/licence_facade.rb
@@ -21,7 +21,7 @@ class LicenceFacade
       fields: %w[title licence_short_description licence_identifier link],
     ).to_h
   rescue GdsApi::BaseError => e
-    message = e.class.name
+    message = e.class.name.dup
     message << "(#{e.code})" if e.respond_to?(:code)
     Rails.logger.warn "#{message} fetching licence details from Rummager"
     raw_data


### PR DESCRIPTION
These are the necessary changes for upgrading Ruby to 2.7.1

There is an automated process for changing the Ruby version across all apps, so updating the code but leaving the Ruby version as 2.6.6.

There's one deprecation error coming from the Capybara gem in 2.7.1. 