### PR TITLE
Ignore 'GdsApi::ContentStore::ItemNotFound' during data sync

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
       activesupport (>= 4.2.0)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk_app_config (2.5.0)
+    govuk_app_config (2.5.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.4.0)

--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,0 +1,3 @@
+GovukError.configure do |config|
+  config.data_sync_excluded_exceptions << "GdsApi::ContentStore::ItemNotFound"
+end


### PR DESCRIPTION
This PR updates govuk_app_config to [v2.5.1](https://github.com/alphagov/govuk_app_config/blob/master/CHANGELOG.md#251), which allows us to declare exceptions that should be ignored if they occur during the nightly [data sync](https://docs.publishing.service.gov.uk/manual/govuk-env-sync.html).

We're adding 'GdsApi::ContentStore::ItemNotFound' as there were 594 events in Sentry overnight:

```
GdsApi::ContentStore::ItemNotFound
URL: https://content-store.integration.govuk-internal.digital/content/licence-finder
```

This happened around 1am, during the nightly data sync. We should
ignore such errors when they happen during the data sync.

Trello: https://trello.com/c/rAlvGlSp/2123-5-ignore-data-sync-errors-in-govukappconfig