### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@ library("govuk")
 
 node('elasticsearch-6.7 && mongodb-2.4') {
   govuk.buildProject(
-    sassLint: false,
     repoName: 'licence-finder',
     brakeman: true,
   )


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80