### PR TITLE
Use core-layout

### DIFF
--- a/app/assets/stylesheets/_conditionals.scss
+++ b/app/assets/stylesheets/_conditionals.scss
@@ -1,10 +1,3 @@
-// Media query helpers. These make producing IE layouts
-// super easy.
-
-// These are desktop and down media queries
-
-// There is also a local version of this in Smartanswers.
-
 $is-ie: false !default;
 
 @mixin media-down($size: false, $max-width: false, $min-width: false) {
@@ -17,16 +10,6 @@ $is-ie: false !default;
       @media (max-width: 800px) {
         @content;
       }
-    }
-  }
-}
-
-// mixins from toolkit, only used now by static and whitehall
-
-@mixin ie-lte($version) {
-  @if $is-ie {
-    @if $ie-version <= $version {
-      @content;
     }
   }
 }

--- a/app/assets/stylesheets/_conditionals.scss
+++ b/app/assets/stylesheets/_conditionals.scss
@@ -1,0 +1,40 @@
+// Media query helpers. These make producing IE layouts
+// super easy.
+
+// These are desktop and down media queries
+
+// There is also a local version of this in Smartanswers.
+
+$is-ie: false !default;
+
+@mixin media-down($size: false, $max-width: false, $min-width: false) {
+  @if $is-ie == false {
+    @if $size == mobile {
+      @media (max-width: 640px) {
+        @content;
+      }
+    } @else if $size == tablet {
+      @media (max-width: 800px) {
+        @content;
+      }
+    }
+  }
+}
+
+// mixins from toolkit, only used now by static and whitehall
+
+@mixin ie-lte($version) {
+  @if $is-ie {
+    @if $ie-version <= $version {
+      @content;
+    }
+  }
+}
+
+@mixin ie($version) {
+  @if $is-ie {
+    @if $ie-version == $version {
+      @content;
+    }
+  }
+}

--- a/app/assets/stylesheets/_core.scss
+++ b/app/assets/stylesheets/_core.scss
@@ -1,0 +1,153 @@
+// Core global styles
+body {
+  @include ie(8) {
+    min-width: 1024px;
+  }
+}
+
+p {
+  @include govuk-font(19);
+}
+
+h2,
+h3,
+h4 {
+  font-weight: 400;
+}
+
+h2 {
+  @include govuk-font(24);
+  margin-top: .5em;
+  margin-bottom: .25em;
+}
+
+h3 {
+  @include govuk-font(19);
+  margin-top: .5em;
+  margin-bottom: .25em;
+}
+
+h4 {
+  @include govuk-font(19);
+  margin-top: .5em;
+  margin-bottom: .25em;
+}
+
+// Page headers
+header.page-header div { // stylelint-disable-line selector-no-qualifying-type
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(6);
+    margin-bottom: govuk-spacing(6);
+  }
+
+  h1 {
+    @extend %govuk-heading-xl;
+    background-repeat: no-repeat;
+    color: $text-colour;
+    font-weight: 600;
+
+    span {
+      @include govuk-font($size: 27, $line-height: 1);
+      display: block;
+      margin-bottom: .25em;
+      text-shadow: none;
+      color: $secondary-text-colour;
+    }
+  }
+}
+
+// Licence Application
+.relevant-authority {
+  margin: 0 0 govuk-spacing(4) 84px;
+
+  h2 {
+    margin: 0;
+  }
+}
+
+.licence .intro form {
+  ul {
+    padding-left: 12px;
+  }
+
+  li {
+    list-style: none;
+
+    label {
+      padding-left: govuk-spacing(1);
+    }
+  }
+}
+
+// Stuff (mainly) used in publications
+
+// Meta-data
+.meta-data {
+  @include govuk-font(16);
+  color: $secondary-text-colour;
+
+  p {
+    text-align: left;
+
+    a {
+      color: $secondary-text-colour;
+    }
+    @include govuk-font(16);
+  }
+}
+
+// Error messages
+.error-notification {
+  border: 1px solid #ffc946;
+  background-color: #fbedcd;
+  padding: 0 1em;
+  margin-bottom: 1em;
+
+  p {
+    @include govuk-font(16);
+  }
+}
+
+.close {
+  margin: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+
+  a {
+    background-color: transparent;
+    background-image: image-url("close.png");
+    background-position: 50% 50%;
+    background-repeat: no-repeat;
+    display: block;
+    margin: 0;
+    height: 2em;
+    width: 2em;
+    text-indent: -9999px;
+
+    &:hover {
+      background-color: rgba(0, 0, 0, .25);
+    }
+  }
+}
+
+.sets-cookie {
+  @include govuk-font(14);
+}
+
+.cookie-container {
+  margin: 0;
+  position: absolute;
+  bottom: 1em;
+  right: 1em;
+}
+
+.find-location-for-service .cookie-container {
+  bottom: 1em;
+  right: .75em;
+
+  @include media-down(mobile) {
+    bottom: govuk-spacing(4);
+    right: 16px;
+  }
+}

--- a/app/assets/stylesheets/_multi-step.scss
+++ b/app/assets/stylesheets/_multi-step.scss
@@ -1,6 +1,3 @@
-// This is basically Smart Answers & Licence Finder & Finance Finder
-// Additional Smart Answers specific css can be found in the smart-answers repo
-
 // Questions
 .hint {
   @include govuk-font(16);

--- a/app/assets/stylesheets/_multi-step.scss
+++ b/app/assets/stylesheets/_multi-step.scss
@@ -1,0 +1,186 @@
+// This is basically Smart Answers & Licence Finder & Finance Finder
+// Additional Smart Answers specific css can be found in the smart-answers repo
+
+// Questions
+.hint {
+  @include govuk-font(16);
+  display: block;
+}
+
+.done-questions {
+  position: relative;
+}
+
+.start-again {
+  background: #ffffff;
+  position: absolute;
+  right: 0;
+  top: -2.5em;
+  height: 2.5em;
+  width: 11em;
+
+  a {
+    @include govuk-font(19, $line-height: 40 / 19);
+    display: block;
+    text-align: center;
+    text-decoration: underline;
+
+    @include govuk-media-query($from: tablet) {
+      @include govuk-font(19, $line-height: 40 / 13);
+    }
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  @include media-down(mobile) {
+    position: static;
+    width: auto;
+    padding: 0 1em;
+
+    a {
+      text-align: right;
+    }
+  }
+}
+
+.question-number {
+  padding-right: .5em;
+}
+
+// stylelint-disable selector-no-qualifying-type, max-nesting-depth
+.done-questions ol,
+.upcoming-questions ol {
+  background-color: #ffffff;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  z-index: 1;
+
+  li {
+    list-style: none;
+    position: relative;
+    padding: .75em 1.5em .75em 1em;
+
+    @include media-down(mobile) {
+      padding: .5em 1em;
+    }
+
+    h3 {
+      @include govuk-font(16);
+    }
+
+    &.done {
+      background: #d5ecea;
+      border-bottom: solid 1px #b6d6d2;
+      overflow: hidden;
+      padding-right: 9.5em;
+
+      .answer {
+        @include govuk-font(16, $weight: bold);
+        color: #315843;
+        display: block;
+        margin: 0 .5em 0 1em;
+
+        &.multiple {
+          display: block;
+
+          ul {
+            margin-top: 0;
+
+            li {
+              margin: 0;
+              padding: 0;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+// stylelint-enable selector-no-qualifying-type, max-nesting-depth
+
+.upcoming-questions {
+  clear: both;
+}
+
+.upcoming-questions ol {
+  li {
+    background-color: #f0e7d7;
+    border-bottom: solid 1px #dac39c;
+  }
+}
+
+.question .question-number {
+  font-weight: normal;
+}
+
+li.done .undo { // stylelint-disable-line selector-no-qualifying-type
+  position: absolute;
+  top: (.75em / .9);
+  right: (1.5em / .9);
+  margin: 0;
+  @include govuk-font(14);
+
+  a {
+    color: $text-colour;
+    display: block;
+  }
+}
+
+li.done .answer ul { // stylelint-disable-line selector-no-qualifying-type
+  margin: .5em 0 0 -2.1em;
+  padding-left: 2.1em;
+}
+
+li.done:hover .undo a { // stylelint-disable-line selector-no-qualifying-type
+  color: inherit;
+}
+
+.step.current {
+  background-color: #ffffff;
+  margin-right: 15em;
+  padding: 0 10em 1em 0;
+  position: relative;
+
+  @include media-down(tablet) {
+    margin-right: 0;
+    padding: 0 1em 1em;
+  }
+}
+
+.next-question {
+  margin: 1.5em 0 .5em;
+}
+
+// Results / outcome
+.outcome {
+  background-color: #ffffff;
+  float: none;
+  margin-right: 0;
+  min-height: 480px;
+
+  .inner {
+    padding-top: 2em;
+  }
+}
+
+// Errors messages
+.content-block .error,
+article .error {
+  border: 1px solid #b01117;
+  background-color: #fff3cf;
+  color: #b01117;
+  margin: 0 0 -.5em -.5em;
+  padding: .5em;
+
+  ul {
+    margin-bottom: 0;
+  }
+}
+
+.error-message {
+  margin-top: 0;
+  color: #b01117;
+}

--- a/app/assets/stylesheets/_publisher.scss
+++ b/app/assets/stylesheets/_publisher.scss
@@ -1,5 +1,3 @@
-// visited link colour overrides
-
 // stylelint-disable selector-max-id
 #content.multi-page li a:visited,
 #content.multi-page .pagination li a:visited {

--- a/app/assets/stylesheets/_publisher.scss
+++ b/app/assets/stylesheets/_publisher.scss
@@ -1,0 +1,338 @@
+// visited link colour overrides
+
+// stylelint-disable selector-max-id
+#content.multi-page li a:visited,
+#content.multi-page .pagination li a:visited {
+  color: $link-visited-colour;
+}
+
+#content.multi-page {
+  header {
+    position: relative;
+  }
+
+  aside {
+    z-index: 10;
+    border-bottom: 1px solid #bbbbbb;
+    margin-bottom: 1em;
+    padding-bottom: 1em;
+    overflow: hidden;
+
+    @include govuk-media-query($from: tablet) {
+      margin: 0 0 2.5em;
+    }
+  }
+}
+
+#content.single-page {
+  header div {
+    padding-bottom: 1em;
+  }
+}
+// stylelint-enable selector-max-id
+
+.video-guide {
+  .content-block .inner,
+  article .inner {
+    padding-bottom: 2em;
+  }
+
+  .meta-data {
+    border-top: none;
+    margin: 1em 0 2em 2em;
+  }
+}
+
+.licence .content-block .inner,
+.licence article .inner {
+  padding-top: 0;
+}
+
+// stylelint-disable max-nesting-depth, selector-no-qualifying-type
+aside .page-navigation {
+
+  @include media-down(mobile) {
+    margin-top: 0;
+  }
+
+  ol {
+    margin: 0;
+    padding: 0;
+    float: left;
+    display: inline;
+    overflow: hidden;
+    width: 50%;
+
+    @include media-down(mobile) {
+      float: none;
+      display: block;
+      width: auto;
+    }
+  }
+
+  li {
+    list-style: decimal;
+    list-style-position: outside;
+    margin-right: .75em;
+    margin-left: 1.5em;
+    clear: left;
+    @include govuk-font(16);
+
+    @include media-down(mobile) {
+      float: none;
+      margin: 0 1em 0 2.25em;
+    }
+
+    a {
+      display: block;
+      padding: .25em 1em .25em 0;
+
+      span {
+        cursor: pointer;
+      }
+
+      &:hover span.part-title,
+      &:focus span.part-title,
+      &:hover span.part-description,
+      &:focus span.part-description {
+        color: $link-hover-colour;
+      }
+    }
+
+    span {
+      &.part-number {
+        display: none;
+        width: 1.75em;
+      }
+
+      &.part-label,
+      &.part-title {
+        line-height: 1.5;
+        display: inline;
+      }
+
+      &.part-label {
+        color: $text-colour;
+        padding: 0 .5em 0 0;
+      }
+
+      &.part-description {
+        line-height: 1.25;
+        display: block;
+        clear: left;
+      }
+
+      &.part-title {
+        color: #2e3191;
+        text-decoration: underline;
+        line-height: 1.5;
+      }
+    }
+
+    &.active {
+      padding-top: .25em;
+      padding-bottom: .25em;
+
+      span.part-number {
+        padding: 0;
+      }
+
+      span.part-title {
+        color: $text-colour;
+        text-decoration: none;
+      }
+    }
+
+    @include media-down(mobile) {
+      &.active {
+        padding: 0;
+      }
+
+      @include govuk-font(19, $line-height: (45 / 19));
+
+      span,
+      a {
+        margin: 0 -1em 0 -2.25em;
+        padding: 0 1em .75em 2.75em;
+      }
+
+      span {
+        display: block;
+
+        &.part-title,
+        &.part-label {
+          display: inline;
+        }
+
+        &.part-label {
+          padding-right: 1em;
+        }
+      }
+    }
+  }
+
+  ol[start] li {
+    margin-left: 1.8em;
+
+    @include media-down(mobile) {
+      margin-left: 2.25em;
+    }
+  }
+}
+// stylelint-enable max-nesting-depth, selector-no-qualifying-type
+
+// guides pagination
+
+// stylelint-disable selector-no-qualifying-type
+.pagination {
+  display: block;
+  margin: 4em 0 0;
+  border-bottom: 1px solid $border-colour;
+
+  @include media-down(mobile) {
+    margin: 2em 0 0;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+  }
+
+  li {
+    @include govuk-font(16, $line-height: (20 / 16));
+    float: left;
+    list-style: none;
+    text-align: right;
+    margin: 0;
+    padding: 0;
+    width: 49%;
+
+    a {
+      background-color: transparent;
+      display: block;
+      color: $link-colour;
+      text-decoration: none;
+
+      &:hover,
+      &:active {
+        background-color: $canvas-colour;
+      }
+
+      .pagination-label { // stylelint-disable-line max-nesting-depth
+        @include govuk-font(27, $line-height: (33.75 / 27));
+        margin-bottom: .1em;
+        display: block;
+      }
+
+      .pagination-part-title { // stylelint-disable-line max-nesting-depth
+        text-decoration: underline;
+      }
+    }
+
+    &.next {
+      float: right;
+      text-align: right;
+    }
+
+    &.next a:before {
+      background: transparent image-url("arrow-sprite.png") no-repeat -102px -11px;
+      margin: -4px -32px 0 0;
+      display: block;
+      float: right;
+      width: 30px;
+      height: 38px;
+      content: " ";
+    }
+
+    &.previous a:before {
+      background: transparent image-url("arrow-sprite.png") no-repeat -20px -11px;
+      margin: -4px 0 0 -32px;
+      display: block;
+      float: left;
+      width: 30px;
+      height: 38px;
+      content: " ";
+    }
+
+    &.previous {
+      float: left;
+      text-align: left;
+    }
+
+    &.previous a {
+      padding: .75em 0 .75em 3em;
+    }
+
+    &.next a {
+      padding: .75em 3em .75em 0;
+    }
+
+    @include media-down(mobile) {
+      &.previous,
+      &.next {
+        float: none;
+        width: 100%;
+      }
+
+      &.next a {
+        text-align: right;
+      }
+    }
+  }
+
+  .first,
+  .last {
+    min-height: 4.5em;
+
+    span {
+      display: block;
+      min-height: 4.5em;
+      padding: .75em 5%;
+      width: 90%;
+    }
+
+    .pagination-label {
+      display: block;
+      margin-bottom: .5em;
+    }
+  }
+}
+// stylelint-enable selector-no-qualifying-type
+
+// Transactions and local transactions styles
+
+.find-location-for-service,
+.find-location-for-licence {
+  background-color: $panel-colour;
+  min-height: 2em;
+  line-height: 2;
+  margin: 2em 0;
+  padding: 1em .75em 1em 1em;
+  position: relative;
+
+  @include media-down(mobile) {
+    margin: 1.2em 0;
+    padding-left: 1em;
+    padding-right: 1em;
+
+    .postcode {
+      margin-left: 0;
+    }
+  }
+
+  p.geolocate-me { // stylelint-disable-line selector-no-qualifying-type
+    border-top: 1px solid $border-colour;
+    @include govuk-font(16);
+    margin-bottom: 0;
+    padding-top: 1em;
+
+    @include media-down(mobile) {
+      margin-left: -2.5em;
+      padding-right: 2.5em;
+    }
+  }
+
+  input[type="submit"] {
+    border-color: $border-colour;
+  }
+}

--- a/app/assets/stylesheets/_text.scss
+++ b/app/assets/stylesheets/_text.scss
@@ -1,0 +1,594 @@
+// Text styles for articles.
+
+.content-block,
+article {
+  h1 {
+    @include govuk-font(24, $weight: bold);
+    margin-top: 1.5em;
+    margin-bottom: .75em;
+  }
+
+  header h1 {
+    @include govuk-font(27, $weight: bold);
+    font-weight: 700;
+    color: $text-colour;
+    margin-top: 0;
+    margin-bottom: 0;
+
+    span {
+      @include govuk-font(16);
+      display: block;
+      margin-bottom: .4em;
+    }
+  }
+
+  h1 + h2 {
+    margin-top: .75em;
+  }
+
+  h2 {
+    @include govuk-font(24, $weight: bold);
+    margin: 1.2em 0 .4em;
+  }
+
+  h2 + h3 {
+    margin-top: .75em;
+  }
+
+  h3 {
+    @include govuk-font(19, $weight: bold);
+    margin-top: 1em;
+    margin-bottom: .75em;
+  }
+
+  h3 + h4 {
+    margin-top: .75em;
+  }
+
+  h4 {
+    margin-top: 1.5em;
+    margin-bottom: 0;
+  }
+
+  h3 + table {
+    margin-top: .652em;
+  }
+
+  h4 + table {
+    margin-top: .75em;
+  }
+
+  h2 + p,
+  h3 + p,
+  h4 + p,
+  h2 + ol,
+  h3 + ol,
+  h4 + ol,
+  h2 + ul,
+  h3 + ul,
+  h4 + ul {
+    margin-top: .2em;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    color: $text-colour;
+  }
+
+  p,
+  ul,
+  ol {
+    margin: .75em 0;
+  }
+
+  p {
+    @include govuk-font(19);
+  }
+
+  p + .help-notice {
+    margin-top: 2em;
+  }
+
+  li {
+    @include govuk-font(19);
+    margin: .25em 0;
+    padding-left: .3em;
+
+    @include media-down(mobile) {
+      margin-left: 16px;
+      padding-left: 0;
+    }
+
+    ul,
+    ol {
+      margin: 0;
+      list-style-position: inside;
+    }
+
+    li {
+      @include govuk-font(19);
+      list-style-type: circle;
+    }
+
+    p {
+      @include govuk-font(19);
+      margin: 0;
+    }
+  }
+
+  ul,
+  ol {
+    padding-left: 1em;
+    margin-top: .75em;
+    margin-bottom: .75em;
+
+    @include media-down(mobile) {
+      padding-left: 0;
+      margin-left: 0;
+    }
+  }
+
+  // Example has a green background, so we need an additional indent to
+  // avoid the bullets hanging on the edge of the colour.
+  .example ul,
+  .example ol {
+    margin-left: .5em;
+  }
+
+  ul {
+    list-style-type: circle;
+    list-style-image: image-url("bullet-disc-5px.gif");
+  }
+
+  ol {
+    list-style-type: decimal;
+  }
+
+  table ul {
+    padding-left: .75em;
+    margin: 0;
+  }
+
+  table ul li:last-child {
+    margin-bottom: 0;
+  }
+
+  dl {
+    margin-top: 1.5em;
+    margin-bottom: 1.88em;
+  }
+
+  dt {
+    @include govuk-font(19);
+    margin-bottom: .25em;
+  }
+
+  dd {
+    margin-bottom: .75em;
+  }
+
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    margin: 1em 0 2em;
+    width: 100%;
+    @include media-down(mobile) {
+      margin: 1em 0 2em;
+      width: 100%;
+    }
+  }
+
+  table caption {
+    @include govuk-font(24, $weight: bold);
+    margin: .4em .5em .4em .7em;
+    text-align: left;
+
+    @include media-down(mobile) {
+      padding-left: 0;
+    }
+  }
+
+  th,
+  td {
+    @include govuk-font(16, $tabular: true);
+    vertical-align: top;
+    padding: .75em .5em .75em 0;
+  }
+
+  td {
+    border-bottom: solid 1px $border-colour;
+
+    small {
+      @include govuk-font(16);
+    }
+  }
+
+  th {
+    line-height: 1.25em;
+    text-align: left;
+    font-weight: 700;
+    border-bottom: solid 1px $border-colour;
+  }
+
+  // More article formatting including markdown styles.
+
+  .mainstream & .summary {
+    margin: 0 0 2em;
+    padding: 0;
+    color: $text-colour;
+
+    p {
+      @include govuk-font(19);
+    }
+
+    @include media-down(mobile) {
+      margin: 0 0 2em;
+      padding: 0;
+    }
+  }
+
+  .summary p,
+  .summary h2 {
+    border: none;
+    margin: 0 .75em 0 0;
+  }
+
+  .summary h2 {
+    line-height: 1.35em;
+  }
+
+  .licence-finder &.outcome ul { // stylelint-disable-line selector-no-qualifying-type
+    padding: 1em;
+    margin: 0 -1em;
+
+    li {
+      list-style-type: none;
+      list-style-image: none;
+      margin: 0 0 .75em;
+      padding: 0;
+    }
+  }
+
+  .advisory {
+    background: image-url("icon-information.png") no-repeat scroll 98% 1em #d5e8f3;
+    line-height: 1.3em;
+    margin: 0 -1em 1em;
+    padding: 1em;
+    text-align: left;
+
+    @include govuk-device-pixel-ratio {
+      background-image: image-url("icon-information-2x.png");
+      background-size: 27px 27px;
+    }
+
+    p {
+      margin: 0 .75em 0 0;
+      min-height: 1.75em;
+      padding-right: 3em;
+    }
+
+    strong {
+      font-weight: 400;
+    }
+
+    &.high-alert {
+      background-color: $panel-colour;
+      border-color: #cc0000;
+    }
+
+    @include media-down(mobile) {
+      margin: 0 0 1em;
+    }
+  }
+
+  .intro {
+    margin-bottom: 1.5em;
+    padding-bottom: 1em;
+
+    .get-started-intro > p:first-child {
+      margin-top: 0;
+    }
+
+    @include media-down(mobile) {
+      margin: 0 0 1.5em;
+      padding: 0;
+    }
+  }
+
+  #wrapper.place & .intro { // stylelint-disable-line selector-max-id
+    margin-bottom: 0;
+  }
+
+  .example {
+    border-left: 10px solid $panel-colour;
+    padding-left: 1.5em;
+    margin: 2.5em 0;
+
+    strong {
+      display: block;
+    }
+
+    @include media-down(mobile) {
+      margin: .75 0;
+    }
+  }
+
+  .application-notice,
+  .advisory.minor,
+  .form-download,
+  .subscribe {
+    padding: .25em 0 .25em 3.5em;
+
+    @include media-down(mobile) {
+      margin: 1em 0 1.5em;
+    }
+  }
+
+  .application-notice {
+    padding: .1em 0 .1em 1em;
+  }
+
+  .advisory.minor {
+    background-image: none;
+    padding: .75em 1em;
+  }
+
+  .help-notice {
+    background: none;
+    background: image-url("icon-important.png") no-repeat scroll 0 .5em;
+
+    @include govuk-device-pixel-ratio {
+      background-image: image-url("icon-important-2x.png");
+      background-size: 34px 34px;
+    }
+
+    p {
+      font-weight: 600;
+    }
+
+    p a {
+      font-weight: 600;
+    }
+  }
+
+  a.important { // stylelint-disable-line selector-no-qualifying-type
+    background: image-url("icon-important.png") no-repeat scroll 100% 0 #ffffff;
+  }
+
+  .subscribe {
+    background: image-url("icon-calendar.png") no-repeat scroll 98% 1em #d5e8f3;
+
+    @include govuk-device-pixel-ratio {
+      background-image: image-url("icon-calendar-2x.png");
+      background-size: 27px 27px;
+    }
+  }
+
+  .info-notice {
+    background: none;
+    border-left: 10px solid $border-colour;
+    margin-bottom: 1em;
+
+    &:after {
+      clear: both;
+      content: "";
+      display: block;
+    }
+  }
+
+  .help-notice p,
+  .info-notice p,
+  .subscribe p {
+    padding-right: 4em;
+  }
+
+  .info-notice p {
+    padding: 0 1em 0 0;
+  }
+
+  .help-notice p { // stylelint-disable no-duplicate-selectors
+    padding: 0 1em 0 2em;
+  }
+
+  p + .help-notice,
+  p + .info-notice {
+    margin-top: 2em;
+  }
+
+  .form-download {
+    padding: .25em 0;
+  }
+
+  .form-download p {
+    padding-right: 3em;
+  }
+
+  .form-download a {
+    display: block;
+    font-weight: 600;
+    background: image-url("icon-file-download.png") no-repeat scroll 0 0;
+    min-height: 2.5em;
+    padding: 0 0 0 2.5em;
+
+    @include govuk-device-pixel-ratio {
+      background-image: image-url("icon-file-download-2x.png");
+      background-size: 25px 25px;
+    }
+  }
+
+  .address {
+    margin: 2.5em 0;
+    min-width: 35%;
+  }
+
+  h2 + .address,
+  h3 + .address {
+    margin-top: .5em;
+  }
+
+  // stylelint-disable selector-no-qualifying-type
+  ol.places {
+    list-style-type: none;
+    padding-left: 0;
+    margin-left: 0;
+
+    &.answer_locations .information {
+      min-height: 3em;
+    }
+
+    li {
+      margin: 0;
+      padding-left: 0;
+    }
+  }
+  // stylelint-enable selector-no-qualifying-type
+
+  .place {
+    margin: 1.5em 0;
+    border-bottom: solid 1px $border-colour;
+    padding-bottom: 1.5em;
+
+    .address {
+      margin: 0;
+      padding: 0;
+      width: auto;
+      display: block;
+    }
+
+    .url {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .additional-information {
+      @include govuk-font(16);
+    }
+
+    .additional-information p {
+      margin: .25em 0;
+    }
+
+    @include media-down(mobile) {
+      margin: .75em 0;
+    }
+  }
+
+  // stylelint-disable selector-no-qualifying-type
+  ul.view-maps {
+    list-style: none;
+    padding: 0;
+    margin: 1em 0;
+
+    li {
+      @include govuk-font(16);
+      display: inline-block;
+      margin-right: 1em;
+    }
+  }
+
+  ol.steps {
+    padding-left: 0;
+    margin-left: 0;
+    overflow: hidden;
+
+    > li {
+      background-position: 0 .87em;
+      background-repeat: no-repeat;
+      list-style-type: decimal;
+      margin-left: 0;
+      padding: .75em 0 .75em 2.2em;
+
+      @for $i from 1 through 14 {
+        &:nth-child(#{$i}) {
+          background-image: image-url("icon-steps/icon-step-#{$i}.png");
+
+          @include govuk-device-pixel-ratio { // stylelint-disable-line  max-nesting-depth
+            background-image: image-url("icon-steps/icon-step-#{$i}-2x.png");
+            background-size: 24px 24px;
+          }
+        }
+      }
+    }
+  }
+  // stylelint-enable selector-no-qualifying-type
+}
+
+.contact {
+  margin: .75em 0;
+  min-width: 60%;
+
+  dl {
+    dt {
+      font-weight: bold;
+      margin: 0 0 .25em;
+    }
+
+    dd {
+      margin: 0 0 .5em;
+    }
+  }
+
+  @include media-down(mobile) {
+    margin: .75em 0;
+  }
+}
+
+section.places h3 { // stylelint-disable-line selector-no-qualifying-type
+  margin-top: 0;
+}
+
+.meta-data .contact {
+  width: auto;
+}
+
+.contact dl dt,
+.meta-data .contact dt {
+  float: left;
+  clear: left;
+}
+
+.contact dl dd,
+.meta-data .contact dd {
+  margin-left: 8.5em;
+}
+
+.highlight-answer,
+.highlighted-event {
+  background-color: #28a197;
+  color: #ffffff;
+  text-align: center;
+  padding: .1em 2em .2em;
+  margin: 0 -1em 1em;
+
+  p {
+    line-height: 2.3em;
+    color: #ffffff;
+
+    em {
+      font-size: 2.45em;
+      font-style: normal;
+      font-weight: 700;
+      display: block;
+      margin-bottom: .5em;
+      color: #ffffff;
+    }
+  }
+
+  @include media-down(mobile) {
+    margin: 0 0 1em;
+
+    @include govuk-font(48);
+
+    p {
+      font-size: 1em;
+      line-height: inherit;
+    }
+
+    p em {
+      font-size: 1em;
+      display: inline;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,5 @@
-$govuk-typography-use-rem: false;
 $govuk-compatibility-govuktemplate: true;
+$govuk-use-legacy-palette: false;
 
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';
@@ -13,6 +13,24 @@ $govuk-compatibility-govuktemplate: true;
 @import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/select';
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
+
+// Map a few legacy variables to `govuk-frontend` equivalents
+// to avoid introducing a dependency on govuk_frontend_toolkit
+$text-colour: $govuk-text-colour;
+$secondary-text-colour: $govuk-secondary-text-colour;
+$link-visited-colour: $govuk-link-visited-colour;
+$link-hover-colour: $govuk-link-colour;
+$border-colour: $govuk-border-colour;
+$link-colour: $govuk-link-colour;
+$canvas-colour: govuk-colour('light-grey');
+$panel-colour: govuk-colour('light-grey');
+
+// Ported from static layout
+@import 'conditionals';
+@import 'core';
+@import 'multi-step';
+@import 'publisher';
+@import 'text';
 
 /* see multi-step.css.erb in the static repo for most of these styles */
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Template
 
-  slimmer_template "wrapper"
+  slimmer_template "core_layout"
 
   if ENV["BASIC_AUTH_USERNAME"]
     http_basic_authenticate_with(


### PR DESCRIPTION
Licence finder is the last standing frontend application (aside from `static`) that uses assets from `govuk_frontend_toolkit` and the only remaining one using what we call 'the `wrapper` layout' or ['wrapper slimmer template'](https://github.com/alphagov/static/blob/master/docs/slimmer_templates.md#wrapper-deprecated). 

Since we're not actively working on this app, but we don't want this dependency to stop us from dropping `govuk_frontend_toolkit` in `static`, we port the [required styles from static](https://github.com/alphagov/licence-finder/pull/914/files) to here (PR to remove them from static coming up) and map a few variables so we don't need to call them from `govuk_frontend_toolkit`. Note that `helpers/mixins` and `helpers/wrapper` are not ported as they are [made available to this app as part of the `core_layout`](https://github.com/alphagov/static/blob/master/app/assets/stylesheets/core-layout.scss).

This change also allows us to turn legacy colour pallette off and use new colours.

[Trello card](https://trello.com/c/Dpe7MWQp/2-frontend-applications-use-inconsistent-frontend-layouts)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1439" alt="Screenshot 2021-01-29 at 15 59 29" src="https://user-images.githubusercontent.com/788096/106298009-45ea8a00-624b-11eb-8577-03a787af5d5c.png">


</td><td valign="top">

<img width="1438" alt="Screenshot 2021-01-29 at 16 00 18" src="https://user-images.githubusercontent.com/788096/106298020-48e57a80-624b-11eb-825b-3a68520bd960.png">


</td></tr>
<tr><td valign="top">

![www gov uk_licence-finder_sectors](https://user-images.githubusercontent.com/788096/106297038-3dde1a80-624a-11eb-9134-c43ff47bb1b1.png)


</td><td valign="top">

![www integration publishing service gov uk_licence-finder_sectors_cachebust=29Jan](https://user-images.githubusercontent.com/788096/106297077-446c9200-624a-11eb-8eaf-eed7c80bb301.png)


</td></tr>
<tr><td valign="top">

![www gov uk_licence-finder_location_sectors=3 activities=183](https://user-images.githubusercontent.com/788096/106297129-4df5fa00-624a-11eb-9f49-36a6c827545b.png)


</td><td valign="top">

![www integration publishing service gov uk_licence-finder_location_sectors=3 activities=183 cache=12](https://user-images.githubusercontent.com/788096/106297134-50585400-624a-11eb-8161-ce7502bf8e62.png)


</td></tr>
<tr><td valign="top">

![www gov uk_licence-finder_licences_activities=183 location=england sectors=3](https://user-images.githubusercontent.com/788096/106297103-4898af80-624a-11eb-8111-711e6d156943.png)


</td><td valign="top">

![www integration publishing service gov uk_licence-finder_licences_activities=183 location=england sectors=3 cachebust=123](https://user-images.githubusercontent.com/788096/106297117-4b93a000-624a-11eb-8085-c6d5b88cfa04.png)


</td></tr>
</table>
