### PR TITLE
Remove unnecessary GovukError config

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,3 +1,0 @@
-GovukError.configure do |config|
-  config.data_sync_excluded_exceptions << "GdsApi::ContentStore::ItemNotFound"
-end


### PR DESCRIPTION
This exception is already being ignored by default:
https://github.com/alphagov/govuk_app_config/blob/b5f76dd7920ccee294c6e862336265980c9eb323/lib/govuk_app_config/govuk_error/configure.rb#L64