### PR TITLE
Add a "browse licences" page which lists all licences

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "govuk-content-schema-test-helpers"
   gem "govuk_test"
+  gem "listen"
   gem "pry-rails"
   gem "rspec-rails"
   gem "rubocop-govuk"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,9 @@ GEM
     kramdown (2.3.1)
       rexml
     link_header (0.0.8)
+    listen (3.5.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     logstasher (2.1.5)
       activesupport (>= 5.2)
       request_store
@@ -245,6 +248,9 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.2)
     rake (13.0.6)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     regexp_parser (2.1.1)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -378,6 +384,7 @@ DEPENDENCIES
   govuk_frontend_toolkit
   govuk_publishing_components
   govuk_test
+  listen
   mongoid
   mongoid_rails_migrations
   plek

--- a/app/assets/stylesheets/_text.scss
+++ b/app/assets/stylesheets/_text.scss
@@ -139,7 +139,6 @@ article {
 
   ul {
     list-style-type: circle;
-    list-style-image: image-url("bullet-disc-5px.gif");
   }
 
   ol {

--- a/app/views/licence_finder/browse_licences.html.erb
+++ b/app/views/licence_finder/browse_licences.html.erb
@@ -1,0 +1,10 @@
+<% content_for :page_title, "All licences - Licence Finder" %>
+
+<article>
+  <h2>All Licences</h2>
+  <ul>
+    <% @licences.each do |licence| %>
+      <li><%= render :partial => 'licence', :object => licence %></li>
+    <% end %>
+  </ul>
+</article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,5 @@ Rails.application.routes.draw do
   get "#{APP_SLUG}/browse-sectors/index" => "licence_finder#browse_sector_index", :as => :browse_sector_index
   get "#{APP_SLUG}/browse-sectors/:sector" => "licence_finder#browse_sector", :as => :browse_sector
   get "#{APP_SLUG}/browse-sectors/:sector_parent/:sector" => "licence_finder#browse_sector_child", :as => :browse_sector_child
+  get "#{APP_SLUG}/browse-licences" => "licence_finder#browse_licences", :as => :browse_licences
 end

--- a/spec/controllers/licence_finder_controller_spec.rb
+++ b/spec/controllers/licence_finder_controller_spec.rb
@@ -310,4 +310,24 @@ RSpec.describe LicenceFinderController, type: :controller do
       end
     end
   end
+
+  describe "GET 'browse licences'" do
+    it "gets fewer than 100 licences" do
+      allow(Licence).to receive(:order_by).and_return(Licence)
+      allow(Licence).to receive(:all).and_return(%i[a b c])
+      allow(LicenceFacade).to receive(:create_for_licences).and_return(%i[d e f])
+
+      get :browse_licences
+      expect(assigns[:licences]).to eq(%i[d e f])
+    end
+
+    it "batches requests for more than 100 licences to avoid overloading search api" do
+      allow(Licence).to receive(:order_by).and_return(Licence)
+      allow(Licence).to receive(:all).and_return((1..200))
+      expect(LicenceFacade).to receive(:create_for_licences).twice.and_return(%i[a b c], %i[d e f])
+
+      get :browse_licences
+      expect(assigns[:licences]).to eq(%i[a b c d e f])
+    end
+  end
 end


### PR DESCRIPTION
This is to answer a question from BEIS about which licences actually
exist in the licence-finder tool.

I considered adding a rake task to export this information. However, it
takes less than 1 second to compute everything (on my local machine).
And it's not sensitive. So it may as well be a public facing page.

This will also mean we don't have to get a developer to re-run a rake
task if someone wants this information in the future. We can just tell
them to go to www.gov.uk/licence-finder/browse-licences and they'll see
them all.

I've got it to serve the X-Robots-Tag header to stop search engines from
indexing this bit of the site - it can be our little secret.

Licence-finder pages are all cached for 30 mintues (this default is set
in ApplicationController), so there should be no risk of this being
accidentally expensive.

<details>
<summary>Screenshot of the page running locally</summary>

![image](https://user-images.githubusercontent.com/1696784/125633430-18eab50a-5681-4df1-86ba-e85f93090a21.png)

</details>