### PR TITLE
Add a route for licence-finder/browse-licences

### DIFF
--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -5,6 +5,7 @@ class PublishingApiNotifier
     "/licence-finder/location" => "45cb0572-d71a-4c22-a84f-fdc53c2e7bc4",
     "/licence-finder/licences" => "e1dc997a-3afe-4180-8c8d-880e7c1ca5a1",
     "/licence-finder/browse-sectors" => "2cae8a3f-1231-4379-bdca-1de9b4668508",
+    "/licence-finder/browse-licences" => "8fbc9c1d-4816-4692-82f0-5cc8358a47cc",
   }.freeze
 
   def self.publish


### PR DESCRIPTION
For historical reasons, /licence-finder is an "exact" route with a
backend_id of "frontend".

All the other /licence-finder routes are prefix routes, but since they
don't share a common prefix, they all have to be presented to router-api
separately. We present them to router-api by presenting them to
publishing-api, which presents them to content-store, which presents
them to router-api. What do you mean it sounds complicated? Pfff

Since I want to add a new route (licence-finder/browse-licences), I need
to present this to the system using the rake task.

I've added this in the same way as the others. The UUID is meaningless -
I generated it by running `uuidgen | tr '[:upper:]' '[:lower:]'`.