### PR TITLE
Rake task to add Costs Lawyers Practising Certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Licence Finder is a public facing GOV.UK application that helps users determine 
 
 This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).
 
+There is more documentation in [the docs directory](docs), for example [Adding new licences to licence-finder](docs/adding-new-licences.md) and [Notes on `gds_id`](docs/notes-on-gds-id.md).
+
 You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
 **Use GOV.UK Docker to run any commands that follow.**

--- a/docs/adding-new-licences.md
+++ b/docs/adding-new-licences.md
@@ -1,0 +1,18 @@
+Adding new licences to licence-finder
+=====================================
+
+For most of licence-finder's history, we haven't added any new licences. So the
+process for adding them is not very mature.
+
+In [a1ad3ff](https://github.com/alphagov/licence-finder/pull/1006/commits/a1ad3ff3)
+we added [a rake task](https://github.com/alphagov/licence-finder/blob/a1ad3ff3/lib/tasks/data_import.rake#L29-L72)
+to specifically add a licence for "costs lawyers practicising certificate"
+(which was requested by BEIS).
+
+This approach should work well enough if we occasionally need to add one or two
+new licences to the tool. However, we should attempt to persuade the departments
+requesting these changes to batch them up as much as possible, to reduce the
+amount of toil we have to do.
+
+There's no pattern for adding batches of licences yet. We'll have to invent
+something when we need it.

--- a/docs/notes-on-gds-id.md
+++ b/docs/notes-on-gds-id.md
@@ -1,0 +1,60 @@
+Notes on `gds_id`
+=================
+
+The format of `gds_id` is interesting.
+
+All the numbers in the databasse are of the form `\d{4}-[1-8]-\d'. Looks
+suspiciously like it's formatted to be meaningful, right? But what does it mean?
+
+It turns out the first part (the four digit bit before the dash) is a reference
+to the "Local government services list (LGSL)":
+
+[https://standards.esd.org.uk/?uri=list%2FenglishAndWelshServices][]
+
+These are things like "Abnormal load notification (785)".
+
+It looks like an old attempt at a register of services, but it hasn't been
+maintained.  Even when the initial licence import happened, most of the licences
+didn't have matching IDs in the LGSL.
+
+From oral history, we have worked out that Dai made up prefixes for the licences
+that weren't in the LGSL. He started at 9048 (for some reason), and then added
+them sequentially all the way up to 9265.
+
+New licences have been added starting from 9266.
+
+Looking at the data in the database, the next digit after the dash is
+always [1-8]. Most of the time it's 7. So that clearly has some meaning
+too.
+
+Again, from oral history we worked out that this is a region identifier:
+
+1 - England
+2 - Wales
+3 - Scotland
+4 - Northern Ireland
+5 - England & Wales
+6 - England & Wales & Scotland
+7 - England & Wales & Scotland & Northern Ireland
+
+(Aside: they've tried to cram four bits of information into a three bit
+number here, so it's not possible to represent any combinations of two
+nations [other than england and wales] or any combinations of three
+countries [other than england, wales and scotland]. I guess this has
+never come up in practice!?)
+
+There's one service in the database which has 8 as the middle number.
+This looks like a mistake.
+
+The final digit (after the second dash) is there to make sure the IDs are
+unique. So if there is more than one licence for the same service, targeting the
+same nations we can still have unique IDs. For new licences this can always be
+1, because we're not trying to group licences into services.
+
+All of this is an interesting aside, but I'm pretty sure the fact that the ID is
+meaningful is a huge red herring - there's nothing that parses it, so it may as
+well just be a random UUID.
+
+Software engineering lesson: don't imbue IDs with unnecessary meaning.  Use
+something you can guarantee will be unique (like a uuid, or an incrementing
+integer), and store the meaningful bits somewhere else on the record.

--- a/lib/tasks/data_import.rake
+++ b/lib/tasks/data_import.rake
@@ -25,4 +25,49 @@ namespace :data_import do
     # Now migrate the imported licences to use the new gds_id
     LicenceDataMigrator.migrate
   end
+
+  desc "Import costs lawyers practicising certificate"
+  task costs_lawyers_practicsing_certificate: :environment do
+    gds_id_prefix = 9266 # Should be one more than the max ID from the database - Licence.pluck(:gds_id).max
+
+    # region_code:
+    # 1 - England
+    # 2 - Wales
+    # 3 - Scotland
+    # 4 - Northern Ireland
+    # 5 - England & Wales
+    # 6 - England & Wales & Scotland
+    # 7 - England & Wales & Scotland & Northern Ireland
+    region_code = 5
+
+    unique_suffix = 1 # Can always be 1, since we're incrementing the prefix so they're always unique
+
+    gds_id = "#{gds_id_prefix}-#{region_code}-#{unique_suffix}"
+
+    if Licence.where(gds_id: gds_id).any?
+      raise "There's already a licence for gds_id #{gds_id}"
+    end
+
+    licence = Licence.new
+
+    licence.da_england = true
+    licence.da_wales = true
+    licence.da_scotland = false
+    licence.da_northern_ireland = false
+
+    licence.gds_id = gds_id
+
+    max_correlation_id = Licence.pluck(:correlation_id).max.to_i
+    licence.correlation_id = (max_correlation_id + 1).to_s
+
+    licence.name = "Costs Lawyer's practising certificate (England & Wales)"
+    licence.regulation_area = "Professional, legal and financial services" # Pick one from Licence.distinct(:regulation_area), or "Other"
+    licence.save!
+
+    ll = LicenceLink.new
+    ll.licence = licence
+    ll.sector_id = Sector.find_by(name: "Solicitor services").id
+    ll.activity_id = Activity.find_by(name: "Offer professional legal services").id
+    ll.save!
+  end
 end


### PR DESCRIPTION
Colleagues from BEIS have asked us to add this licence to
licence-finder.

It will point to a start page on GOV.UK that links off to the CLSB's
website (i.e. it's not a new licence on licensify).

Apparently the CLSB reached out in April to ask for this, but it's only
just made it into our awareness. It's probably still not that much of a
priority, but it's a good opportunity to work out "how do we actually
add licences to licence-finder?".

From what I've been able to tell from the git history, we've never added
a new licence to licence-finder since the initial data import in 2012 🙈

The closest thing I could find was commit 7c46f89d (from 2013) which
fixes some bits of data which were incorrect in the initial import.

Because we haven't done this in the last 8 years, I had to do quite a
bit of archaeology to work out how everything works. People did not
write good commit messages back in those days. Thankfully we live in a
more civilised age.

The main interesting thing is the format of `gds_id` - all the numbers
in the databasse are of the form `\d{4}-[1-8]-\d'. Looks suspiciously
like it's formatted to be meaningful, right? But what does it mean?

It turns out the first part is a reference to the "Local government
services list (LGSL)":

https://standards.esd.org.uk/?uri=list%2FenglishAndWelshServices

These are things like "Abnormal load notification (785)". It looks like
an old attempt at a register of services, but it hasn't been maintained.
Even when the initial licence import happened, most of the licences
didn't have matching IDs in the LGSL.

From oral history, we worked out that Dai made up prefixes for the
licences that weren't in the LGSL. He started at 9048 (for some reason),
and then added them sequentially all the way up to 9265.

So it makes sense for us to use 9266 as the prefix for our new licence.

Looking at the data in the database, the next digit after the dash is
always [1-8]. Most of the time it's 7. So that clearly has some meaning
too.

Again, from oral history we worked out that this is a region identifier:

1 - England
2 - Wales
3 - Scotland
4 - Northern Ireland
5 - England & Wales
6 - England & Wales & Scotland
7 - England & Wales & Scotland & Northern Ireland

(Aside: they've tried to cram four bits of information into a three bit
number here, so it's not possible to represent any combinations of two
nations [other than england and wales] or any combinations of three
countries [other than england, wales and scotland]. I guess this has
never come up in practice!?

There's one service in the database which has `8` as the middle number.
This looks like a mistake.

The final digit (after the second dash) is there to make sure the IDs
are unique. So if there are more than one licence for the same service,
targeting the same nations we can still have unique IDs. For our
purposes this can always be 1, because we're not trying to group
licences into services.

All of this was an interesting aside, but I'm pretty sure the fact that
the ID is meaningful is a huge red herring - there's nothing that parses
it, so it may as well just be a random UUID.

Software engineering lesson: don't imbue IDs with unnecessary meaning.
Use something you can guarantee will be unique (like a uuid, or an
incrementing integer), and store the meaningful bits somewhere else on
the record.

Now that we've worked all that out we can actually add the licence
entry. BEIS want it under Solicitor services / Offer professional legal
services, which we can do by adding a licence link.

I've made this task check if the licence is already there and error if
it is, so we don't need to remove it from the repo once it's run. It can
serve as an explanation of how to do this next time.

Because this is just a single licence, I've hardcoded everything in the
rake task. If we need to add batches of licences in the future we should
probably do something a bit better. There's no prior art in the git
history though.

Finally, once this has been added to licence-finder, we'll also need to
add a licence artefact in publisher
(https://publisher.publishing.service.gov.uk/artefacts/new). Publisher
will ask us for the ID, which will be 9266-5-1. This will end up in
search-api, which is how licence-finder turns our entry into a link to
the start page.