### PR TITLE
Fix search results when pagination happens

### DIFF
--- a/app/models/licence_facade.rb
+++ b/app/models/licence_facade.rb
@@ -1,6 +1,6 @@
 class LicenceFacade
   def self.create_for_licences(licences)
-    search_results = search_licences(licences)["results"]
+    search_results = search_licences(licences)
 
     licences.map do |licence|
       matching_search_data = search_results.find do |search_result|
@@ -12,14 +12,14 @@ class LicenceFacade
   end
 
   def self.search_licences(licences)
-    raw_data = { "results" => [] }
+    raw_data = []
 
     return raw_data if licences.empty?
 
-    GdsApi.search.search(
+    GdsApi.search.search_enum(
       filter_licence_identifier: licences.map(&:gds_id).map(&:to_s),
       fields: %w[title licence_short_description licence_identifier link],
-    ).to_h
+    ).to_a
   rescue GdsApi::BaseError => e
     message = e.class.name.dup
     message << "(#{e.code})" if e.respond_to?(:code)


### PR DESCRIPTION
Previously `create_for_licences` made no attempt to paginate through
pages of search results. If you made a query which would return more
than the pagination limit, it would just return the first page and throw
away the rest.

The search API client has a search_enum method which does the pagination
for us. Calling `.to_a` forces it to go through all the pages and load
them into an array, which is consistent with what was there before.
There's no need to pluck out the `["results"]` anymore - that's an
artefact of a single page of results, so search_enum handles this for
us.

I believe this is only causing an issue on
www.gov.uk/licence-finder/browse-licences (which I added recently in
https://github.com/alphagov/licence-finder/pull/1004). That makes calls
to search-api 100 licences at a time, but each request only gets the
first page of results, so it makes it look like there are far fewer
results than there actually are.

<details>
<summary>Comparison of screenshots in integration (where this is deployed) and production</summary>

| Integration | Production |
|----|----|
| ![image](https://user-images.githubusercontent.com/1696784/125956110-ddd77b0b-cb8c-4e8e-9dcf-441eb80ea53d.png) | ![image](https://user-images.githubusercontent.com/1696784/125956014-a7c3a02b-59e1-4583-8350-46c3c9c5f453.png) |

</details>