### PR TITLE
Swap to `gem_layout` and adopt new link styles

### DIFF
--- a/app/assets/stylesheets/_core.scss
+++ b/app/assets/stylesheets/_core.scss
@@ -41,10 +41,12 @@ header.page-header div { // stylelint-disable-line selector-no-qualifying-type
   }
 
   h1 {
-    @extend %govuk-heading-xl;
+    @include govuk-text-colour;
+    @include govuk-font($size: 48, $weight: bold);
+    @include govuk-responsive-margin(8, "bottom");
     background-repeat: no-repeat;
-    color: $text-colour;
-    font-weight: 600;
+    display: block;
+    margin-top: 0;
 
     span {
       @include govuk-font($size: 27, $line-height: 1);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 $govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
+$govuk-new-link-styles: true;
 
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/components/breadcrumbs';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,8 +1,7 @@
-$govuk-compatibility-govuktemplate: true;
+$govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
 
 @import 'govuk_publishing_components/govuk_frontend_support';
-@import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/breadcrumbs';
 @import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/error-message';

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,14 +1,14 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Template
 
-  slimmer_template "core_layout"
-
   if ENV["BASIC_AUTH_USERNAME"]
     http_basic_authenticate_with(
       name: ENV.fetch("BASIC_AUTH_USERNAME"),
       password: ENV.fetch("BASIC_AUTH_PASSWORD"),
     )
   end
+
+  slimmer_template :gem_layout
 
 protected
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,8 +28,6 @@
         </header>
         <%= yield %>
       </main>
-
-      <%= render 'govuk_publishing_components/components/feedback' %>
     </div>
   </body>
 </html>


### PR DESCRIPTION
### What

Update `licence-finder` to use the Design System-based page layout and turn on the `govuk-new-link-styles` flag.

### Why

Major benefits include performance improvements, accessibility improvements, and consistency with other applications.

### Visual changes
No visual changes.

