### PR TITLE
Fix the Dockerfile so it produces a workable image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,35 +5,26 @@ ENV RAILS_ENV=production
 # TODO: have a separate build image which already contains the build-only deps.
 RUN apt-get update -qy && \
     apt-get upgrade -y && \
-    apt-get install -y build-essential nodejs && \
-    apt-get clean
-
+    apt-get install -y build-essential nodejs
 RUN mkdir /app
 WORKDIR /app
-COPY Gemfile* .ruby-version /app/
+COPY Gemfile* .ruby-version ./
 RUN bundle config set deployment 'true' && \
     bundle config set without 'development test' && \
     bundle install -j8 --retry=2
-
-COPY . /app
+COPY . ./
 # TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
 RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk \
     GOVUK_APP_DOMAIN=www.gov.uk \
     bundle exec rails assets:precompile
 
-
 FROM $base_image
-
-ENV RAILS_ENV=production GOVUK_APP_NAME=license-finder
-
+ENV RAILS_ENV=production GOVUK_APP_NAME=licence-finder
 RUN apt-get update -qy && \
     apt-get upgrade -y && \
     apt-get install -y nodejs && \
-    apt-get clean 
-
-COPY --from=builder /usr/local/bundle/ /user/local/bundle/
+    apt-get clean
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
-
 WORKDIR /app
-
 CMD bundle exec puma


### PR DESCRIPTION
- Typo in the destination path: s/user/usr/
- Wrong spelling in GOVUK_APP_NAME: s/license/licence/ (both the app repo and govuk-puppet consistently use the UK spelling).

Also some minor cleanup while we're there:

- Remove unnecessary `apt clean` step from the build stage.
- Clean up some of the blank lines so that the two stages can be more clearly seen.
- Use relative paths so that `/app` isn't repeated quite so many times.

https://trello.com/c/F7vSHnws/841

Tested: `docker buildx build . -t licence-finder && docker run -e GOVUK_APP_DOMAIN=foo -e GOVUK_WEBSITE_ROOT=foo -e SECRET_KEY_BASE=foo -p 3000:3000 -it --rm licence-finder`. Container starts up correctly and is able to receive requests. I didn't hook it up to Content Store to see it actually generate a page — it's easier to test that in situ after merge.