### PR TITLE
Fix schema violation in CI GitHub Action.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,7 @@
 name: CI
 
 on:
-  workflow_dispatch:
-    branches:
-      - main
+  workflow_dispatch: {}
   push:
     branches:
       - main


### PR DESCRIPTION
This fixes the container build / push to ECR. It seems GitHub started validating this more strictly recently.

Tested: [ran from PR branch](https://github.com/alphagov/licence-finder/actions/runs/2246068218)