### PR TITLE
Adding soft link to /tmp filesystem.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,21 +5,24 @@ ENV RAILS_ENV=production
 # TODO: have a separate build image which already contains the build-only deps.
 
 # Add yarn to apt sources
-RUN apt-get update && apt-get install -y curl && apt-get install -y gnupg
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update && \
+    apt-get install -y curl gnupg
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
 RUN apt-get update -qy && \
     apt-get upgrade -y && \
     apt-get install -y build-essential yarn
 RUN mkdir /app
 WORKDIR /app
-COPY Gemfile* .ruby-version package.json yarn.lock ./
+COPY Gemfile* .ruby-version package.json yarn.lock /app/
+
 RUN bundle config set deployment 'true' && \
     bundle config set without 'development test' && \
     bundle install -j8 --retry=2
 RUN yarn install --production --frozen-lockfile
-COPY . ./
+COPY . /app
 # TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
 RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk \
     GOVUK_APP_DOMAIN=www.gov.uk \
@@ -31,7 +34,17 @@ RUN apt-get update -qy && \
     apt-get upgrade -y && \
     apt-get install -y nodejs && \
     apt-get clean
+
+RUN mkdir /app && ln -fs /tmp /app
+
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
+
 WORKDIR /app
+
+RUN groupadd -g 1001 app && \
+    useradd app -u 1001 -g 1001 --home /app
+ 
+USER app
+
 CMD bundle exec puma


### PR DESCRIPTION
This should allow writing to /app/tmp directory and fix the current permission denied errors
in EKS.

This is part of non-root container work:
https://trello.com/c/Jef1t4xU/903-fix-app-permission-errors-due-to-nonroot