### PR TITLE
Symlink needed updating.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,10 @@ RUN apt-get update -qy && \
     apt-get install -y nodejs && \
     apt-get clean
 
-RUN mkdir /app && ln -fs /tmp /app
-
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
+
+RUN mv /app/tmp / && ln -fs /tmp /app
 
 WORKDIR /app
 


### PR DESCRIPTION
Due to /app/tmp files that where generated during the builder stage.

https://trello.com/c/Jef1t4xU/903-fix-app-permission-errors-due-to-nonroot