### PR TITLE
Remove stylesheets and JavaScript included in Static

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,6 @@
 //= require jquery/dist/jquery
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/button
-//= require govuk_publishing_components/components/feedback
 
 /*globals $ */
 /*jslint

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,14 +3,6 @@ $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 
 @import 'govuk_publishing_components/govuk_frontend_support';
-@import 'govuk_publishing_components/components/breadcrumbs';
-@import 'govuk_publishing_components/components/button';
-@import 'govuk_publishing_components/components/error-message';
-@import 'govuk_publishing_components/components/feedback';
-@import 'govuk_publishing_components/components/heading';
-@import 'govuk_publishing_components/components/hint';
-@import 'govuk_publishing_components/components/input';
-@import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/select';
 @import 'govuk_publishing_components/components/step-by-step-nav-header';
 

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,3 +1,2 @@
 @import 'govuk_publishing_components/govuk_frontend_support';
-@import 'govuk_publishing_components/components/print/button';
 @import 'govuk_publishing_components/components/print/step-by-step-nav-header';


### PR DESCRIPTION
## What

Remove stylesheets and JavaScript imports that are already included in the stylesheet and JavaScript files served by `static`.

## Why

To avoid a duplication of code - this is already being downloaded by the user via the `static` stylesheets and JavaScript files - so doesn't need to be downloaded twice. Removing the duplicated code from licence finder means that a page will load quicker.

## Visual changes

None.
