### PR TITLE
Remove button component JavaScript

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,5 @@
 //= require jquery/dist/jquery
 //= require govuk_publishing_components/lib
-//= require govuk_publishing_components/components/button
 
 /*globals $ */
 /*jslint


### PR DESCRIPTION
## What

Remove include of the button component's JavaScript from this app's JavaScript.

## Why

This is now included in `static`'s JavaScript (https://github.com/alphagov/static/pull/2820), so can be removed from this app.

## Visual changes

None.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
