### PR TITLE
Update healthcheck to include Mongoid connectivity test.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
-  get "/healthcheck/ready", to: GovukHealthcheck.rack_response
+  get "/healthcheck/ready", to: GovukHealthcheck.rack_response(GovukHealthcheck::Mongoid)
 
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 


### PR DESCRIPTION

Healthcheck for licence-finder currently isn't including the automatic Mongoid support, add this to improve the healthcheck.