### PR TITLE
Replace govuk-content-schema-test-helpers with govuk_schemas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "uglifier"
 group :development, :test do
   gem "database_cleaner-mongoid"
   gem "factory_bot_rails"
-  gem "govuk-content-schema-test-helpers"
+  gem "govuk_schemas"
   gem "govuk_test"
   gem "listen"
   gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,8 +143,6 @@ GEM
       rest-client (~> 2.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_app_config (4.6.3)
       logstasher (~> 2.1)
       prometheus_exporter (~> 2.0)
@@ -166,6 +164,8 @@ GEM
       rails (>= 6)
       rouge
       sprockets (>= 3)
+    govuk_schemas (4.3.0)
+      json-schema (~> 2.8.0)
     govuk_test (3.0.1)
       brakeman (>= 5.0.2)
       capybara (>= 3.36)
@@ -426,10 +426,10 @@ DEPENDENCIES
   elasticsearch (~> 6)
   factory_bot_rails
   gds-api-adapters
-  govuk-content-schema-test-helpers
   govuk_app_config
   govuk_frontend_toolkit
   govuk_publishing_components
+  govuk_schemas
   govuk_test
   listen
   mongo (= 2.14.0)

--- a/spec/presenters/licence_finder_content_item_presenter_spec.rb
+++ b/spec/presenters/licence_finder_content_item_presenter_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe LicenceFinderContentItemPresenter do
   let(:subject) { LicenceFinderContentItemPresenter.new("/licence-finder/sectors", "4ade13fa-7e79-4bee-b809-61dbe5c3aa22") }
@@ -11,7 +11,7 @@ RSpec.describe LicenceFinderContentItemPresenter do
 
   describe "#payload" do
     it "is valid against the schema" do
-      expect(subject.payload).to be_valid_against_schema("generic")
+      expect(subject.payload).to be_valid_against_publisher_schema("generic")
     end
 
     it "has the correct data" do

--- a/spec/support/govuk_schemas.rb
+++ b/spec/support/govuk_schemas.rb
@@ -1,0 +1,3 @@
+require "govuk_schemas/rspec_matchers"
+
+RSpec.configuration.include GovukSchemas::RSpecMatchers

--- a/spec/support/schema_tests.rb
+++ b/spec/support/schema_tests.rb
@@ -1,8 +1,0 @@
-require "govuk-content-schema-test-helpers/rspec_matchers"
-
-GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = "publisher_v2"
-  config.project_root = Rails.root
-end
-
-RSpec.configuration.include GovukContentSchemaTestHelpers::RSpecMatchers


### PR DESCRIPTION
replace tests using deprecated gem govuk-content-schema-test-helpers with tests from govuk_schemas gem.

https://trello.com/c/b9PRFqgU/231-applications-use-govuk-content-schema-test-helpers-which-is-an-archived-gem