### PR TITLE
Update Dockerfile to use GOV.UK Ruby base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,19 @@
-ARG base_image=ruby:2.7.6-slim-buster
-FROM $base_image AS builder
-
-ENV RAILS_ENV=production
-# TODO: have a separate build image which already contains the build-only deps.
-
-# Add yarn to apt sources
-RUN apt-get update && \
-    apt-get install -y curl gnupg
-
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-
-RUN apt-get update -qy && \
-    apt-get upgrade -y && \
-    apt-get install -y build-essential yarn
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
+FROM $builder_image AS builder
 
 RUN mkdir -p /app && ln -fs /tmp /app/tmp && ln -fs /tmp /home/app
 WORKDIR /app
 COPY Gemfile* .ruby-version package.json yarn.lock /app/
 
-RUN bundle config set deployment 'true' && \
-    bundle config set without 'development test' && \
-    bundle install -j8 --retry=2
+RUN bundle install
 RUN yarn install --production --frozen-lockfile
 COPY . /app
 # TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
-RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk \
-    GOVUK_APP_DOMAIN=www.gov.uk \
-    bundle exec rails assets:precompile
+RUN bundle exec rails assets:precompile
 
 FROM $base_image
-ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=licencefinder
-RUN apt-get update -qy && \
-    apt-get upgrade -y && \
-    apt-get install -y nodejs && \
-    apt-get clean
+ENV GOVUK_APP_NAME=licencefinder
 
 RUN mkdir -p /app && ln -fs /tmp /app/tmp && ln -fs /tmp /home/app
 
@@ -42,9 +21,6 @@ COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
 
 WORKDIR /app
-
-RUN groupadd -g 1001 app && \
-    useradd app -u 1001 -g 1001 --home /app
  
 USER app
 


### PR DESCRIPTION
Updates Dockerfile to use [new Ruby base images](https://github.com/alphagov/govuk-ruby-images). Also removes the patch version from the ruby version file so it doesn't take manual effort to patch Ruby.

Context: https://trello.com/c/Zy0fd25w/689-use-base-builder-images-in-all-the-app-dockerfiles