### PR TITLE
Turn off font

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,11 @@ $govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 
+// This flag stops the font from being included in this application's
+// stylesheet - the font is being served by Static across all of GOV.UK, so is
+// not needed here.
+$govuk-include-default-font-face: false;
+
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/components/select';
 @import 'govuk_publishing_components/components/step-by-step-nav-header';


### PR DESCRIPTION
## What

Prevent the font from being included in `licence-finder`'s stylesheet.

## Why

We should be serving the font files from `static` so they're cached across the entirety of GOVUK - so the font shouldn't be included in `licence-finder`'s stylesheet.

With the font being served by each application, users need to re-download it every time they went from a page rendered in one application to a page rendered in another application.

Serving it from `static` means that the same font URI is used in each application, allowing the fonts to be cached and reused.

## Visual changes

None - the same font is being served from `static`, instead of `licence-finder`.

Before (the font paths contains `licence-finder`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181254853-23a9f980-05f7-4898-88b5-5c15e72a8da7.png">

After (the font path contains `static`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181254875-a8110dff-96a4-45ea-90c6-6e4a1312a095.png">

---

## Search page examples to sanity check:

- https://govuk-licence-finder-pr-1178.herokuapp.com/licence-finder/sectors
- https://www.integration.publishing.service.gov.uk/licence-finder/sectors