### PR TITLE
Use `Plek.new` as `current` is deprecated

### DIFF
--- a/app/models/licence_facade.rb
+++ b/app/models/licence_facade.rb
@@ -53,6 +53,6 @@ class LicenceFacade
 private
 
   def web_url
-    Plek.current.website_root + @search_result["link"]
+    Plek.new.website_root + @search_result["link"]
   end
 end

--- a/spec/models/licence_facade_spec.rb
+++ b/spec/models/licence_facade_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe LicenceFacade, type: :model do
       end
 
       it "should return the frontend url" do
-        expect(@lf.url).to eq(Plek.current.website_root + @pub_data["link"])
+        expect(@lf.url).to eq(Plek.new.website_root + @pub_data["link"])
       end
 
       it "should return the API short description" do


### PR DESCRIPTION
This is causing logging noise.

Trello:
https://trello.com/c/EUn4KnjW/1555-replace-plekcurrent-with-pleknew-in-licencefinder