### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "gds-api-adapters"
 gem "govuk_app_config"
 gem "govuk_frontend_toolkit"
 gem "govuk_publishing_components"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mongo", "2.14.0"
 gem "mongoid", "7.5.2"
 gem "mongoid_rails_migrations"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,11 +195,8 @@ GEM
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -439,6 +436,7 @@ DEPENDENCIES
   govuk_schemas
   govuk_test
   listen
+  mail (~> 2.7.1)
   mongo (= 2.14.0)
   mongoid (= 7.5.2)
   mongoid_rails_migrations


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
