### PR TITLE
Set nofollow on most licence finder pages

### DIFF
--- a/app/controllers/licence_finder_controller.rb
+++ b/app/controllers/licence_finder_controller.rb
@@ -11,6 +11,7 @@ class LicenceFinderController < ApplicationController
 
   before_action :extract_and_validate_sector_ids, except: %i[sectors browse_sector_index browse_sector browse_sector_child browse_licences]
   before_action :extract_and_validate_activity_ids, except: %i[sectors activities browse_sector_index browse_sector browse_sector_child browse_licences]
+  before_action :set_noindex_nofollow, except: %i[browse_licences]
   before_action :set_expiry
   before_action :setup_content_item
   after_action :add_analytics_headers
@@ -150,5 +151,9 @@ protected
     if @sectors && params[:q].present?
       set_slimmer_headers(result_count: @sectors.length)
     end
+  end
+
+  def set_noindex_nofollow
+    response.set_header("X-Robots-Tag", "noindex,nofollow")
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,6 @@
   <head>
     <title><%= content_for?(:page_title) ? yield(:page_title) : "Licence Finder" %> - GOV.UK</title>
     <meta name="description" content="Find out which licences you might need for your activity or business.">
-    <meta name="robots" content="noindex">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "application", :media => "all" %>


### PR DESCRIPTION
Licence finder pages have a lot of links which allow one to combine different filters. Each of these links results in a page which is `noindex`ed, so it's pointless for search engines to crawl. Search engines will also crawl _all_ the links, whether they make any sense as a combination, or not. 

There is some [config already in the app](https://github.com/alphagov/licence-finder/blob/c7fd73b66dbbb4bb524a00e1e7dd828f3f45282b/app/assets/javascripts/application.js#L301) for some links that are generated via javascript, but this doesn't have the desired effect.

This change removes the robots noindex meta tag from the layout, as we want to be slightly more nuanced with the configuration and add nofollow for _most_ but not all pages.

It makes sense for the [browse licences](https://www.gov.uk/licence-finder/browse-licences) page to allow link following, as it links to real pages which are useful for search engines to know about. The others, not so much.

I've adopted using the [X-Robots-Tag header](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#xrobotstag) as it was already used for the browse_licences action, and consolidates on one approach rather than mixing tags and headers which might be confusing.

We've actually [blocked Googlebot from any Licence finder paths](https://github.com/alphagov/govuk-puppet/pull/10410/files) but I'd rather try this approach first, as it keeps the config in the application and might be less surprising. Should the high levels of traffic continue over time, then we might do something more.

