### PR TITLE
Remove ASSET_HOST env var

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,10 +34,6 @@ module LicenceFinder
     # config.eager_load_paths << Rails.root.join("extras")
     config.assets.prefix = "/assets/licencefinder"
 
-    # allow overriding the asset host with an enironment variable, useful for
-    # when router is proxying to this app but asset proxying isn't set up.
-    config.asset_host = ENV["ASSET_HOST"]
-
     config.assets.precompile += %w[
       application.css
       application.js


### PR DESCRIPTION
This env var is no longer in active use since the introduction of Static proxy [1] and usage of it will soon have problems with the Content Security Policy [2].

[1]: https://github.com/alphagov/govuk_app_config/blob/7f060692720df50a27f6845f052b04eae2246226/lib/govuk_app_config/govuk_proxy/static_proxy.rb
[2]: https://github.com/alphagov/govuk_app_config/pull/274

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

