### PR TITLE
Export licence data

### DIFF
--- a/app/controllers/licence_finder_controller.rb
+++ b/app/controllers/licence_finder_controller.rb
@@ -9,8 +9,8 @@ class LicenceFinderController < ApplicationController
   ].freeze
   ACTIONS = %w[sectors activities business_location].freeze
 
-  before_action :extract_and_validate_sector_ids, except: %i[sectors browse_sector_index browse_sector browse_sector_child browse_licences]
-  before_action :extract_and_validate_activity_ids, except: %i[sectors activities browse_sector_index browse_sector browse_sector_child browse_licences]
+  before_action :extract_and_validate_sector_ids, except: %i[sectors browse_sector_index browse_sector browse_sector_child browse_licences licences_api]
+  before_action :extract_and_validate_activity_ids, except: %i[sectors activities browse_sector_index browse_sector browse_sector_child browse_licences licences_api]
   before_action :set_noindex_nofollow, except: %i[browse_licences]
   before_action :set_expiry
   before_action :setup_content_item
@@ -104,6 +104,10 @@ class LicenceFinderController < ApplicationController
     @licences = licences
       .each_slice(search_api_batch_size)
       .flat_map { |batch| LicenceFacade.create_for_licences(batch) }
+  end
+
+  def licences_api
+    render json: DataExporter.call
   end
 
 protected

--- a/app/lib/data_exporter.rb
+++ b/app/lib/data_exporter.rb
@@ -1,0 +1,14 @@
+class DataExporter
+  def self.call
+    new.call
+  end
+
+  def call
+    licences = Licence.all
+    licences.map do |licence|
+      {
+        licence_identifier: licence.gds_id,
+      }
+    end
+  end
+end

--- a/app/lib/data_exporter.rb
+++ b/app/lib/data_exporter.rb
@@ -9,6 +9,7 @@ class DataExporter
       {
         licence_identifier: licence.gds_id,
         locations: locations(licence),
+        industry_sectors: level_two_sectors(licence),
       }
     end
   end
@@ -23,5 +24,13 @@ private
     locations << "northern-ireland" if licence.da_northern_ireland
 
     locations
+  end
+
+  def level_two_sectors(licence)
+    sectors = Sector.in(id: LicenceLink.where(licence_id: licence.id).pluck(:sector_id))
+    sectors.filter_map do |sector|
+      parent_sectors = sector.parents.to_a
+      parent_sectors.first.name.parameterize if parent_sectors.first&.layer == 2
+    end
   end
 end

--- a/app/lib/data_exporter.rb
+++ b/app/lib/data_exporter.rb
@@ -28,9 +28,11 @@ private
 
   def level_two_sectors(licence)
     sectors = Sector.in(id: LicenceLink.where(licence_id: licence.id).pluck(:sector_id))
-    sectors.filter_map do |sector|
+    level_two_sectors = sectors.filter_map do |sector|
       parent_sectors = sector.parents.to_a
       parent_sectors.first.name.parameterize if parent_sectors.first&.layer == 2
     end
+
+    level_two_sectors.uniq
   end
 end

--- a/app/lib/data_exporter.rb
+++ b/app/lib/data_exporter.rb
@@ -8,7 +8,20 @@ class DataExporter
     licences.map do |licence|
       {
         licence_identifier: licence.gds_id,
+        locations: locations(licence),
       }
     end
+  end
+
+private
+
+  def locations(licence)
+    locations = []
+    locations << "england" if licence.da_england
+    locations << "wales" if licence.da_wales
+    locations << "scotland" if licence.da_scotland
+    locations << "northern-ireland" if licence.da_northern_ireland
+
+    locations
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,6 @@ Rails.application.routes.draw do
   get "#{APP_SLUG}/browse-sectors/:sector" => "licence_finder#browse_sector", :as => :browse_sector
   get "#{APP_SLUG}/browse-sectors/:sector_parent/:sector" => "licence_finder#browse_sector_child", :as => :browse_sector_child
   get "#{APP_SLUG}/browse-licences" => "licence_finder#browse_licences", :as => :browse_licences
+
+  get "#{APP_SLUG}/licences-api" => "licence_finder#licences_api", :as => :licences_api
 end

--- a/spec/lib/data_exporter_spec.rb
+++ b/spec/lib/data_exporter_spec.rb
@@ -19,5 +19,18 @@ RSpec.describe DataExporter do
       expect(exported_licences.first[:locations]).to_not include("scotland")
       expect(exported_licences.first[:locations]).to_not include("northern-ireland")
     end
+
+    it "only exports the level two sectors the licence is tagged to" do
+      sector_layer_1 = FactoryBot.create(:sector, name: "Layer 1 Sector", layer: 1)
+      sector_layer_2 = FactoryBot.create(:sector, name: "Layer 2 Sector", layer: 2, parent_ids: [sector_layer_1.id])
+      sector_layer_3 = FactoryBot.create(:sector, name: "Layer 3 Sector", layer: 3, parent_ids: [sector_layer_2.id])
+      licence_link = FactoryBot.create(:licence_link, sector: sector_layer_3, licence:)
+
+      exported_licences = DataExporter.call
+
+      expect(exported_licences.first[:industry_sectors]).to include(sector_layer_2.name.parameterize)
+      expect(exported_licences.first[:industry_sectors]).to_not include(sector_layer_1.name.parameterize)
+      expect(exported_licences.first[:industry_sectors]).to_not include(sector_layer_3.name.parameterize)
+    end
   end
 end

--- a/spec/lib/data_exporter_spec.rb
+++ b/spec/lib/data_exporter_spec.rb
@@ -20,17 +20,30 @@ RSpec.describe DataExporter do
       expect(exported_licences.first[:locations]).to_not include("northern-ireland")
     end
 
-    it "only exports the level two sectors the licence is tagged to" do
-      sector_layer_1 = FactoryBot.create(:sector, name: "Layer 1 Sector", layer: 1)
-      sector_layer_2 = FactoryBot.create(:sector, name: "Layer 2 Sector", layer: 2, parent_ids: [sector_layer_1.id])
-      sector_layer_3 = FactoryBot.create(:sector, name: "Layer 3 Sector", layer: 3, parent_ids: [sector_layer_2.id])
-      licence_link = FactoryBot.create(:licence_link, sector: sector_layer_3, licence:)
+    describe "level two sectors" do
+      let!(:sector_layer_1) { FactoryBot.create(:sector, name: "Layer 1 Sector", layer: 1) }
+      let!(:sector_layer_2) { FactoryBot.create(:sector, name: "Layer 2 Sector", layer: 2, parent_ids: [sector_layer_1.id]) }
+      let!(:sector_layer_3) { FactoryBot.create(:sector, name: "Layer 3 Sector", layer: 3, parent_ids: [sector_layer_2.id]) }
+      let!(:licence_link) { FactoryBot.create(:licence_link, sector: sector_layer_3, licence:) }
 
-      exported_licences = DataExporter.call
+      it "only exports the level two sectors the licence is tagged to" do
+        exported_licences = DataExporter.call
 
-      expect(exported_licences.first[:industry_sectors]).to include(sector_layer_2.name.parameterize)
-      expect(exported_licences.first[:industry_sectors]).to_not include(sector_layer_1.name.parameterize)
-      expect(exported_licences.first[:industry_sectors]).to_not include(sector_layer_3.name.parameterize)
+        expect(exported_licences.first[:industry_sectors].size).to eq(1)
+        expect(exported_licences.first[:industry_sectors]).to include(sector_layer_2.name.parameterize)
+        expect(exported_licences.first[:industry_sectors]).to_not include(sector_layer_1.name.parameterize)
+        expect(exported_licences.first[:industry_sectors]).to_not include(sector_layer_3.name.parameterize)
+      end
+
+      it "removes duplicate level two sectors the licence is tagged to" do
+        another_sector_layer_3 = FactoryBot.create(:sector, name: "Layer 3 Sector", layer: 3, parent_ids: [sector_layer_2.id])
+        FactoryBot.create(:licence_link, sector: another_sector_layer_3, licence:)
+
+        exported_licences = DataExporter.call
+
+        expect(exported_licences.first[:industry_sectors].size).to eq(1)
+        expect(exported_licences.first[:industry_sectors]).to include(sector_layer_2.name.parameterize)
+      end
     end
   end
 end

--- a/spec/lib/data_exporter_spec.rb
+++ b/spec/lib/data_exporter_spec.rb
@@ -10,5 +10,14 @@ RSpec.describe DataExporter do
 
       expect(exported_licences.first[:licence_identifier]).to eq(licence.gds_id)
     end
+
+    it "exports the applicable devolved administrations for each licence" do
+      exported_licences = DataExporter.call
+
+      expect(exported_licences.first[:locations]).to include("england")
+      expect(exported_licences.first[:locations]).to_not include("wales")
+      expect(exported_licences.first[:locations]).to_not include("scotland")
+      expect(exported_licences.first[:locations]).to_not include("northern-ireland")
+    end
   end
 end

--- a/spec/lib/data_exporter_spec.rb
+++ b/spec/lib/data_exporter_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+require "data_exporter"
+
+RSpec.describe DataExporter do
+  describe ".call" do
+    let!(:licence) { FactoryBot.create(:licence) }
+
+    it "exports the gds_id" do
+      exported_licences = DataExporter.call
+
+      expect(exported_licences.first[:licence_identifier]).to eq(licence.gds_id)
+    end
+  end
+end


### PR DESCRIPTION
Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Trello: https://trello.com/c/DY5YCALU

# What's changed?
Adds a JSON endpoint to export the following data for each licence:

- gds_id
- Devolved administrations
- Level 2 sectors

# Why?

Once the data has been exported, it will be imported into Specialist Publisher and used to tag licences to industry sectors in the new "Find Licences" specialist finder.

Facets in specialist finders do not support nested facets, therefore only one level of sectors was required, and level two was selected by the user researchers and content designers for the first round of testing.

Activities were are not being exported as they have an almost one to one mapping with licences, but the activity names do not match the licence names.
