### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "gds-api-adapters"
 gem "govuk_app_config"
 gem "govuk_frontend_toolkit"
 gem "govuk_publishing_components"
-gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mongo", "2.14.0"
 gem "mongoid", "7.5.2"
 gem "mongoid_rails_migrations"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,8 +197,11 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -440,7 +443,6 @@ DEPENDENCIES
   govuk_schemas
   govuk_test
   listen
-  mail (~> 2.7.1)
   mongo (= 2.14.0)
   mongoid (= 7.5.2)
   mongoid_rails_migrations


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the `mail` gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to `2.8.0.1`, which fixes the permissions issue.

Generated with `gsed -i '/gem "mail"/d' && bundle update mail`.
