### PR TITLE
Update jQuery from 1.12.4 to 3.6.3 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: daily
 
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below
   # config redundant, as ruby is the only updatable thing in the

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,7 @@ $(function() {
 
     // $('el:bottom-offscreen') will return true if the element's
     // bottom box border is off the screen
-    $.expr.filters['bottom-offscreen'] = function(el) {
+    $.expr.pseudos['bottom-offscreen'] = function(el) {
         var $window = $(window),
             $el = $(el),
             bottomOfWindow = ($window.scrollTop() + $window.height()),

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "name": "licence-finder",
   "license": "MIT",
   "dependencies": {
-    "jquery": "1.12.4"
+    "jquery": "3.6.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-jquery@1.12.4:
-  version "1.12.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
-  integrity sha1-AeHfuikP5z3rp3zurLD5ui/sngw=
+jquery@3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.3.tgz#23ed2ffed8a19e048814f13391a19afcdba160e6"
+  integrity sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg==


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

Although there are many reasons to motivate an upgrade of such a legacy
dependency, the main motivation for this change was that jQuery 1.12
triggers CSP violations on initialisation in Firefox (due to [1] which
was removed by jQuery 2.2).

The reason this uses such an old version of jQuery is that we (GOV.UK)
used to share a version of jQuery across many apps and thus it was scary
to update as it was hard to test it's impacts. Since March 2022 [2]
Licence Finder has had it's own version of jQuery and thus it is easier
to judge the impacts.

To determine compatibly with jQuery 3 I ran this through jQuery migrate
[3] and fixed the one warning. I also went through and manually tested
the code setting breakpoints to check various parts were executed.

[1]: https://github.com/jquery/jquery/blob/e09907ce152fb6ef7537a3733b1d65ead8ee6303/src/event/support.js#L7-L20
[2]: https://github.com/alphagov/licence-finder/commit/c384fc507412d57cb8d312dcd3c285c98340fc29
[3]: https://github.com/jquery/jquery-migrate