### PR TITLE
Add ga4 tracking to contextual breadcrumb

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
   </head>
   <body class="mainstream">
     <div id="wrapper" class="answer licence-finder <%= yield :page_class %>">
-      <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item %>
+      <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item, ga4_tracking: true %>
 
       <main id="content" role="main">
         <header class="page-header group">


### PR DESCRIPTION
## What
Enables GA4 tracking on the contextual breadcrumb by adding a `ga4_tracking: true` attribute.

## Why
Part of the GA4 migration.

## Visual changes
N/A

Trello card: https://trello.com/c/AM5JCKEd/430-add-tracking-to-super-breadcrumbs