### PR TITLE
Use Yarn 3 instead of Yarn 1 in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY package.json yarn.lock ./
-RUN yarn install --production --frozen-lockfile --non-interactive --link-duplicates
+RUN yarn set version berry && yarn install --immutable
 COPY . .
 RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log


### PR DESCRIPTION
Updates the container build to reflect #1298.