### PR TITLE
Add rake task to unpublish and redirect routes

### DIFF
--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -14,8 +14,18 @@ class PublishingApiNotifier
     end
   end
 
+  def self.unpublish
+    LICENCE_FINDER_FORM_DETAILS.each do |_base_path, content_id|
+      new.unpublish(content_id)
+    end
+  end
+
   def publish(presenter)
     GdsApi.publishing_api.put_content(presenter.content_id, presenter.payload)
     GdsApi.publishing_api.publish(presenter.content_id)
+  end
+
+  def unpublish(content_id)
+    GdsApi.publishing_api.unpublish(content_id, type: "redirect", alternative_path: "/find-licences")
   end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -3,4 +3,9 @@ namespace :publishing_api do
   task publish: :environment do
     PublishingApiNotifier.publish
   end
+
+  desc "Unpublishes Licence Finder pages in the Publishing API"
+  task unpublish: :environment do
+    PublishingApiNotifier.unpublish
+  end
 end


### PR DESCRIPTION
- All routes redirected to /find-licences (Except /licence-finder itself, which was published by Publisher and will be unpublished there).

https://trello.com/c/Wkj80QfI/2062-create-temp-rake-task-to-redirect-the-old-licence-finder


