### PR TITLE
Remove unicorn config

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3014}

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,2 +1,0 @@
-require "govuk_app_config/govuk_unicorn"
-GovukUnicorn.configure(self)


### PR DESCRIPTION
This app has been decommissioned, however we need to be able to do a comparison analysis with the new application. National Archives couldn't fully scrape the web pages rendered from the application as they were powered by a Mongo database.

The app wouldn't load on Heroku as it still contains the old unicorn config that was causing the app to crash.

Unicorn was dropped in https://github.com/alphagov/govuk_app_config/commit/71f4f2fa3871721e5c8140bcf73d683e09d8d7b2 and has been replaced by Puma

Once the analysis has been completed, this app will be archived again.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

